### PR TITLE
feat: implement group-based expense splitting with equal and custom s…

### DIFF
--- a/models.py
+++ b/models.py
@@ -36,8 +36,14 @@ class Expense(db.Model):
     description = db.Column(db.String(200), nullable=False)
     amount = db.Column(db.Float, nullable=False)
     payer = db.Column(db.String(100), nullable=False)
-    participants = db.Column(db.Text)
+    participants = db.Column(db.Text)  # Keep for backward compatibility during migration
+    group_id = db.Column(db.Integer, db.ForeignKey('group.id'), nullable=True)  # Start as nullable for migration
+    split_type = db.Column(db.String(20), nullable=False, default='equal')  # 'equal' or 'custom'
+    split_details = db.Column(db.Text)  # JSON string: {"member": amount}
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    
+    # Relationship
+    group = db.relationship('Group', backref='expenses')
 
 class Group(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/routes/expenses.py
+++ b/routes/expenses.py
@@ -1,9 +1,10 @@
 """Expense management routes blueprint."""
 
-from flask import Blueprint, redirect, render_template, request, url_for
+import json
+from flask import Blueprint, redirect, render_template, request, url_for, flash
 
 from extensions import db
-from models import Expense
+from models import Expense, Group
 from services.expense_service import ExpenseService
 from utils.decorators import login_required
 
@@ -14,38 +15,142 @@ expenses_bp = Blueprint("expenses", __name__)
 @login_required
 def expense_splitter():
     """Handle expense splitter page - create and view expenses."""
+    # Get all groups for the form
+    groups = Group.query.all()
+    
     if request.method == "POST":
+        # Extract form data
         description = request.form.get("description", "").strip()
         amount_raw = request.form.get("amount", "").strip()
         payer = request.form.get("payer", "").strip()
-        participants = request.form.get("participants", "").strip()
-
+        group_id = request.form.get("group_id", "").strip()
+        split_type = request.form.get("split_type", "equal").strip()
+        
+        # Validate required fields
+        if not description:
+            flash("Description is required", "error")
+            return redirect(url_for("expenses.expense_splitter"))
+        
+        if not group_id:
+            flash("Please select a group", "error")
+            return redirect(url_for("expenses.expense_splitter"))
+        
+        if not payer:
+            flash("Payer is required", "error")
+            return redirect(url_for("expenses.expense_splitter"))
+        
+        # Validate amount
         try:
             amount = float(amount_raw)
-        except ValueError:
-            amount = None
-
-        if description and amount is not None and payer:
-            expense = Expense(
-                description=description,
-                amount=amount,
-                payer=payer,
-                participants=participants or None,
-            )
-            db.session.add(expense)
-            db.session.commit()
-
+            if amount <= 0:
+                flash("Amount must be greater than zero", "error")
+                return redirect(url_for("expenses.expense_splitter"))
+        except (ValueError, TypeError):
+            flash("Please enter a valid amount", "error")
+            return redirect(url_for("expenses.expense_splitter"))
+        
+        # Get selected group
+        group = Group.query.get(group_id)
+        if not group:
+            flash("Selected group not found", "error")
+            return redirect(url_for("expenses.expense_splitter"))
+        
+        # Parse group members
+        group_members = [m.strip() for m in group.members.split(",") if m.strip()]
+        
+        # Validate payer is in group
+        if payer not in group_members:
+            flash("Payer must be a member of the selected group", "error")
+            return redirect(url_for("expenses.expense_splitter"))
+        
+        # Handle participants and split details
+        if split_type == "equal":
+            # Get selected participants for equal split
+            selected_participants = request.form.getlist("participants")
+            if not selected_participants:
+                flash("Please select at least one participant", "error")
+                return redirect(url_for("expenses.expense_splitter"))
+            
+            # Validate all participants are in group
+            for participant in selected_participants:
+                if participant not in group_members:
+                    flash(f"Participant '{participant}' is not in the selected group", "error")
+                    return redirect(url_for("expenses.expense_splitter"))
+            
+            # Calculate equal split
+            split_details = ExpenseService.calculate_equal_split(selected_participants, amount)
+            
+        else:  # custom split
+            # Get custom split amounts
+            split_details = {}
+            for member in group_members:
+                amount_key = f"custom_amount_{member}"
+                custom_amount = request.form.get(amount_key, "").strip()
+                if custom_amount:
+                    try:
+                        split_details[member] = float(custom_amount)
+                    except ValueError:
+                        flash(f"Invalid amount for {member}", "error")
+                        return redirect(url_for("expenses.expense_splitter"))
+            
+            if not split_details:
+                flash("Please specify amounts for at least one participant", "error")
+                return redirect(url_for("expenses.expense_splitter"))
+            
+            # Validate custom split
+            is_valid, error_msg = ExpenseService.validate_custom_split(split_details, amount)
+            if not is_valid:
+                flash(error_msg, "error")
+                return redirect(url_for("expenses.expense_splitter"))
+        
+        # Create expense
+        expense = Expense(
+            description=description,
+            amount=amount,
+            payer=payer,
+            group_id=group_id,
+            split_type=split_type,
+            split_details=json.dumps(split_details),
+            participants=", ".join(split_details.keys())  # Keep for backward compatibility
+        )
+        db.session.add(expense)
+        db.session.commit()
+        
+        flash("Expense added successfully!", "success")
         return redirect(url_for("expenses.expense_splitter"))
 
-    expenses = Expense.query.order_by(Expense.created_at.desc()).all()
+    # GET request - show form and expenses
+    selected_group_id = request.args.get("group_id")
+    
+    # Get expenses (filter by group if specified)
+    if selected_group_id:
+        expenses = Expense.query.filter_by(group_id=selected_group_id).order_by(Expense.created_at.desc()).all()
+    else:
+        expenses = Expense.query.order_by(Expense.created_at.desc()).all()
+    
+    # Process expenses for display
     expense_views = []
     for expense in expenses:
-        people = [p.strip() for p in (expense.participants or "").split(",") if p.strip()]
-        share = expense.amount / len(people) if people else None
-        expense_views.append({"model": expense, "participants": people, "share": share})
+        split_details = ExpenseService._parse_split_details(expense)
+        participants = list(split_details.keys())
+        share = list(split_details.values())[0] if len(split_details) == 1 and split_type == "equal" else None
+        expense_views.append({
+            "model": expense, 
+            "participants": participants, 
+            "share": share,
+            "split_details": split_details
+        })
+
+    # Convert groups to JSON-serializable format
+    groups_data = [{"id": group.id, "name": group.name, "members": group.members} for group in groups]
 
     return render_template(
-        "apps/expense_splitter/index.html", page_id="expense-splitter", expenses=expense_views
+        "apps/expense_splitter/index.html", 
+        page_id="expense-splitter", 
+        expenses=expense_views,
+        groups=groups,
+        groups_data=groups_data,
+        selected_group_id=selected_group_id
     )
 
 
@@ -53,15 +158,28 @@ def expense_splitter():
 @login_required
 def balance_summary():
     """Display balance summary showing who owes whom across all expenses."""
-    # Get all expenses from the database
-    expenses = Expense.query.all()
+    # Get group filter if specified
+    group_id = request.args.get("group_id")
+    
+    # Get expenses (filter by group if specified)
+    if group_id:
+        expenses = Expense.query.filter_by(group_id=group_id).all()
+    else:
+        expenses = Expense.query.all()
 
     # Calculate balances using the service
     balance_data = ExpenseService.calculate_balances(expenses)
+    
+    # Get groups for the filter dropdown
+    groups = Group.query.all()
+    groups_data = [{"id": group.id, "name": group.name, "members": group.members} for group in groups]
 
     return render_template(
         "apps/expense_splitter/balance.html",
         page_id="balance-summary",
         balances=balance_data["balances"],
         transactions=balance_data["transactions"],
+        groups=groups,
+        groups_data=groups_data,
+        selected_group_id=group_id
     )

--- a/services/expense_service.py
+++ b/services/expense_service.py
@@ -1,5 +1,6 @@
 """Business logic for expense calculations and balance summaries."""
 
+import json
 from collections import defaultdict
 
 
@@ -13,26 +14,17 @@ class ExpenseService:
 
         This function:
         1. Calculates how much each person paid
-        2. Calculates how much each person should pay (equal split)
+        2. Calculates how much each person should pay (based on split_details)
         3. Determines the net balance (what they paid - what they should pay)
 
         Args:
-            expenses: List of Expense model objects with amount, payer, and participants fields
+            expenses: List of Expense model objects with amount, payer, and split_details fields
 
         Returns:
             Dictionary with:
             - 'balances': dict mapping person name to their net balance
               (positive = owed money, negative = owes money)
             - 'transactions': list of simplified payment transactions
-
-        Example:
-            expenses = [
-                Expense(amount=30, payer="Alice", participants="Alice, Bob, Charlie"),
-                Expense(amount=60, payer="Bob", participants="Alice, Bob, Charlie")
-            ]
-            result = ExpenseService.calculate_balances(expenses)
-            # result['balances'] = {'Alice': -10, 'Bob': 10, 'Charlie': -20}
-            # Alice owes $10, Bob is owed $10, Charlie owes $20
         """
         if not expenses:
             return {"balances": {}, "transactions": []}
@@ -43,19 +35,18 @@ class ExpenseService:
         should_pay = defaultdict(float)
 
         for expense in expenses:
-            # Parse participants
-            participants = [p.strip() for p in (expense.participants or "").split(",") if p.strip()]
-
-            if not participants:
-                continue
-
             # The payer paid the full amount
             paid[expense.payer] += expense.amount
 
-            # Each participant should pay their share
-            share = expense.amount / len(participants)
-            for participant in participants:
-                should_pay[participant] += share
+            # Parse split details
+            split_details = ExpenseService._parse_split_details(expense)
+            
+            if not split_details:
+                continue
+
+            # Each participant should pay their share based on split_details
+            for participant, amount in split_details.items():
+                should_pay[participant] += amount
 
         # Calculate net balance for each person
         all_people = set(paid.keys()) | set(should_pay.keys())
@@ -123,3 +114,71 @@ class ExpenseService:
                 j += 1
 
         return transactions
+
+    @staticmethod
+    def _parse_split_details(expense):
+        """
+        Parse split details from expense, handling both old and new formats.
+        
+        Args:
+            expense: Expense model object
+            
+        Returns:
+            Dictionary mapping participant names to their share amounts
+        """
+        # Try new format first (split_details JSON)
+        if expense.split_details:
+            try:
+                return json.loads(expense.split_details)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        
+        # Fall back to old format (participants text field)
+        if expense.participants:
+            participants = [p.strip() for p in expense.participants.split(",") if p.strip()]
+            if participants:
+                share = expense.amount / len(participants)
+                return {participant: share for participant in participants}
+        
+        return {}
+
+    @staticmethod
+    def validate_custom_split(split_details, total_amount):
+        """
+        Validate that custom split amounts sum to the total amount.
+        
+        Args:
+            split_details: Dictionary mapping participant names to amounts
+            total_amount: Total expense amount
+            
+        Returns:
+            Tuple of (is_valid, error_message)
+        """
+        if not split_details:
+            return False, "No participants specified"
+        
+        total_split = sum(split_details.values())
+        tolerance = 0.01  # Allow small floating point differences
+        
+        if abs(total_split - total_amount) > tolerance:
+            return False, f"Split amounts ({total_split:.2f}) must equal total amount ({total_amount:.2f})"
+        
+        return True, None
+
+    @staticmethod
+    def calculate_equal_split(participants, total_amount):
+        """
+        Calculate equal split for given participants.
+        
+        Args:
+            participants: List of participant names
+            total_amount: Total expense amount
+            
+        Returns:
+            Dictionary mapping participant names to their equal share
+        """
+        if not participants:
+            return {}
+        
+        share = total_amount / len(participants)
+        return {participant: share for participant in participants}

--- a/templates/apps/expense_splitter/index.html
+++ b/templates/apps/expense_splitter/index.html
@@ -20,6 +20,24 @@
         white-space: nowrap;
         animation: typing 2s steps(30, end);
     }
+    .split-option {
+        display: none;
+    }
+    .split-option.active {
+        display: block;
+    }
+    .member-checkbox {
+        display: none;
+    }
+    .member-checkbox.active {
+        display: block;
+    }
+    .custom-amount {
+        display: none;
+    }
+    .custom-amount.active {
+        display: block;
+    }
 </style>
 {% endblock %}
 
@@ -37,6 +55,19 @@
         </div>
     </div>
 </div>
+
+<!-- Flash Messages -->
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <div class="mb-6">
+            {% for category, message in messages %}
+                <div class="p-4 rounded-lg {% if category == 'error' %}bg-red-100 text-red-700 border border-red-200{% elif category == 'success' %}bg-green-100 text-green-700 border border-green-200{% else %}bg-blue-100 text-blue-700 border border-blue-200{% endif %}">
+                    {{ message }}
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endwith %}
 
 <div class="bg-gradient-to-r from-emerald-50 to-teal-50 rounded-xl p-6 mb-8 border border-emerald-200">
     <div class="flex items-start gap-3">
@@ -66,35 +97,79 @@
             </span>
         </div>
 
-        <form method="POST" action="/expense-splitter" class="space-y-4">
+        <form method="POST" action="/expense-splitter" class="space-y-4" id="expenseForm">
+            <!-- Group Selection -->
             <div>
-                <label for="description" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Description</label>
+                <label for="group_id" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Group *</label>
+                <select id="group_id" name="group_id" required
+                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white">
+                    <option value="">Select a group...</option>
+                    {% for group in groups %}
+                        <option value="{{ group.id }}" {% if selected_group_id == group.id|string %}selected{% endif %}>{{ group.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <!-- Description -->
+            <div>
+                <label for="description" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Description *</label>
                 <input type="text" id="description" name="description"
                     class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
                     placeholder="Project supplies, Team lunch..." required>
             </div>
 
+            <!-- Amount and Payer -->
             <div class="grid grid-cols-2 gap-4">
                 <div>
-                    <label for="amount" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Amount ($)</label>
-                    <input type="number" id="amount" name="amount" step="0.01"
+                    <label for="amount" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Amount ($) *</label>
+                    <input type="number" id="amount" name="amount" step="0.01" min="0.01"
                         class="w-full px-4 py-3 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-2xl font-bold text-cyan-300 placeholder-gray-500"
                         placeholder="0.00" required>
                 </div>
                 <div>
-                    <label for="payer" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Paid By</label>
-                    <input type="text" id="payer" name="payer"
-                        class="w-full px-4 py-3 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
-                        placeholder="@username" required>
+                    <label for="payer" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Paid By *</label>
+                    <select id="payer" name="payer" required
+                        class="w-full px-4 py-3 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white">
+                        <option value="">Select payer...</option>
+                    </select>
                 </div>
             </div>
 
+            <!-- Split Type -->
             <div>
-                <label for="participants" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Split Between</label>
-                <input type="text" id="participants" name="participants"
-                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
-                    placeholder="@alice, @bob, @charlie">
-                <span class="text-xs text-gray-400 mt-1">Comma-separated list of participants</span>
+                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Split Type *</label>
+                <div class="flex gap-4">
+                    <label class="flex items-center">
+                        <input type="radio" name="split_type" value="equal" checked class="mr-2">
+                        <span class="text-sm">Equal Split</span>
+                    </label>
+                    <label class="flex items-center">
+                        <input type="radio" name="split_type" value="custom" class="mr-2">
+                        <span class="text-sm">Custom Split</span>
+                    </label>
+                </div>
+            </div>
+
+            <!-- Participants Selection (Equal Split) -->
+            <div id="equalSplitOptions" class="split-option active">
+                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Participants *</label>
+                <div id="participantsList" class="space-y-2">
+                    <p class="text-sm text-gray-400">Select a group first to see members</p>
+                </div>
+                <div id="equalSplitSummary" class="mt-2 text-sm text-cyan-300" style="display: none;">
+                    <span id="splitAmount">$0.00</span> per person
+                </div>
+            </div>
+
+            <!-- Custom Split Options -->
+            <div id="customSplitOptions" class="split-option">
+                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Custom Amounts *</label>
+                <div id="customAmountsList" class="space-y-2">
+                    <p class="text-sm text-gray-400">Select a group first to see members</p>
+                </div>
+                <div id="customSplitSummary" class="mt-2 text-sm text-cyan-300" style="display: none;">
+                    Total: $<span id="customTotal">0.00</span> / $<span id="customExpected">0.00</span>
+                </div>
             </div>
 
             <button type="submit"
@@ -132,6 +207,11 @@
                                 <span class="text-xs font-mono bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded">
                                     @{{ expense.payer }}
                                 </span>
+                                {% if expense.group %}
+                                <span class="text-xs font-mono bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
+                                    {{ expense.group.name }}
+                                </span>
+                                {% endif %}
                                 <span class="text-xs text-gray-400 font-mono">
                                     {{ expense.created_at.strftime('%Y-%m-%d %H:%M') }}
                                 </span>
@@ -154,7 +234,13 @@
                                         </span>
                                     {% endfor %}
                                 </div>
-                                {% if item.share is not none %}
+                                {% if item.split_details %}
+                                    <div class="text-sm font-mono text-gray-600">
+                                        {% for participant, amount in item.split_details.items() %}
+                                            <span class="block">{{ participant }}: ${{ '%.2f' % amount }}</span>
+                                        {% endfor %}
+                                    </div>
+                                {% elif item.share is not none %}
                                     <span class="text-sm font-mono text-gray-600">
                                         Each: <span class="font-bold text-cyan-600">${{ '%.2f' % item.share }}</span>
                                     </span>
@@ -188,4 +274,185 @@
         <p class="opacity-90">Split expenses fairly! Studies show that transparent expense tracking improves team collaboration by 35%.</p>
     </div>
 </div>
+
+<script>
+// Group data for JavaScript
+const groups = JSON.parse('{{ groups_data|tojson|safe }}') || [];
+
+document.addEventListener('DOMContentLoaded', function() {
+    const groupSelect = document.getElementById('group_id');
+    const payerSelect = document.getElementById('payer');
+    const amountInput = document.getElementById('amount');
+    const splitTypeRadios = document.querySelectorAll('input[name="split_type"]');
+    const equalSplitOptions = document.getElementById('equalSplitOptions');
+    const customSplitOptions = document.getElementById('customSplitOptions');
+    const participantsList = document.getElementById('participantsList');
+    const customAmountsList = document.getElementById('customAmountsList');
+    const equalSplitSummary = document.getElementById('equalSplitSummary');
+    const customSplitSummary = document.getElementById('customSplitSummary');
+    const splitAmount = document.getElementById('splitAmount');
+    const customTotal = document.getElementById('customTotal');
+    const customExpected = document.getElementById('customExpected');
+
+    // Handle group selection
+    groupSelect.addEventListener('change', function() {
+        const groupId = this.value;
+        const group = groups.find(g => g.id == groupId);
+        
+        if (group) {
+            const members = group.members.split(',').map(m => m.trim());
+            
+            // Update payer dropdown
+            payerSelect.innerHTML = '<option value="">Select payer...</option>';
+            members.forEach(member => {
+                const option = document.createElement('option');
+                option.value = member;
+                option.textContent = member;
+                payerSelect.appendChild(option);
+            });
+            
+            // Update participants list for equal split
+            participantsList.innerHTML = '';
+            members.forEach(member => {
+                const div = document.createElement('div');
+                div.className = 'flex items-center';
+                div.innerHTML = `
+                    <input type="checkbox" name="participants" value="${member}" id="participant_${member}" class="mr-2" checked>
+                    <label for="participant_${member}" class="text-sm">${member}</label>
+                `;
+                participantsList.appendChild(div);
+            });
+            
+            // Update custom amounts list
+            customAmountsList.innerHTML = '';
+            members.forEach(member => {
+                const div = document.createElement('div');
+                div.className = 'flex items-center gap-2';
+                div.innerHTML = `
+                    <label class="text-sm w-20">${member}:</label>
+                    <input type="number" name="custom_amount_${member}" step="0.01" min="0" 
+                           class="flex-1 px-2 py-1 bg-slate-950/50 border border-cyan-500/30 rounded text-sm custom-amount-input">
+                `;
+                customAmountsList.appendChild(div);
+            });
+            
+            updateSplitCalculations();
+        } else {
+            payerSelect.innerHTML = '<option value="">Select payer...</option>';
+            participantsList.innerHTML = '<p class="text-sm text-gray-400">Select a group first to see members</p>';
+            customAmountsList.innerHTML = '<p class="text-sm text-gray-400">Select a group first to see members</p>';
+        }
+    });
+
+    // Handle split type change
+    splitTypeRadios.forEach(radio => {
+        radio.addEventListener('change', function() {
+            if (this.value === 'equal') {
+                equalSplitOptions.classList.add('active');
+                customSplitOptions.classList.remove('active');
+            } else {
+                equalSplitOptions.classList.remove('active');
+                customSplitOptions.classList.add('active');
+            }
+            updateSplitCalculations();
+        });
+    });
+
+    // Handle amount change
+    amountInput.addEventListener('input', updateSplitCalculations);
+
+    // Handle participant selection change
+    participantsList.addEventListener('change', updateSplitCalculations);
+
+    // Handle custom amount changes
+    customAmountsList.addEventListener('input', function(e) {
+        if (e.target.classList.contains('custom-amount-input')) {
+            updateSplitCalculations();
+        }
+    });
+
+    function updateSplitCalculations() {
+        const amount = parseFloat(amountInput.value) || 0;
+        const selectedSplitType = document.querySelector('input[name="split_type"]:checked').value;
+        
+        if (selectedSplitType === 'equal') {
+            const selectedParticipants = Array.from(participantsList.querySelectorAll('input[type="checkbox"]:checked'));
+            const participantCount = selectedParticipants.length;
+            
+            if (participantCount > 0 && amount > 0) {
+                const share = amount / participantCount;
+                splitAmount.textContent = '$' + share.toFixed(2);
+                equalSplitSummary.style.display = 'block';
+            } else {
+                equalSplitSummary.style.display = 'none';
+            }
+        } else {
+            const customInputs = customAmountsList.querySelectorAll('.custom-amount-input');
+            let total = 0;
+            customInputs.forEach(input => {
+                total += parseFloat(input.value) || 0;
+            });
+            
+            customTotal.textContent = total.toFixed(2);
+            customExpected.textContent = amount.toFixed(2);
+            
+            if (amount > 0) {
+                customSplitSummary.style.display = 'block';
+                if (Math.abs(total - amount) < 0.01) {
+                    customSplitSummary.className = 'mt-2 text-sm text-green-300';
+                } else {
+                    customSplitSummary.className = 'mt-2 text-sm text-red-300';
+                }
+            } else {
+                customSplitSummary.style.display = 'none';
+            }
+        }
+    }
+
+    // Form validation
+    document.getElementById('expenseForm').addEventListener('submit', function(e) {
+        const amount = parseFloat(amountInput.value);
+        const selectedSplitType = document.querySelector('input[name="split_type"]:checked').value;
+        
+        // Validate amount
+        if (amount <= 0) {
+            e.preventDefault();
+            alert('Amount must be greater than zero');
+            return;
+        }
+        
+        // Validate participants
+        if (selectedSplitType === 'equal') {
+            const selectedParticipants = participantsList.querySelectorAll('input[type="checkbox"]:checked');
+            if (selectedParticipants.length === 0) {
+                e.preventDefault();
+                alert('Please select at least one participant');
+                return;
+            }
+        } else {
+            const customInputs = customAmountsList.querySelectorAll('.custom-amount-input');
+            let total = 0;
+            let hasAnyAmount = false;
+            
+            customInputs.forEach(input => {
+                const value = parseFloat(input.value) || 0;
+                total += value;
+                if (value > 0) hasAnyAmount = true;
+            });
+            
+            if (!hasAnyAmount) {
+                e.preventDefault();
+                alert('Please specify amounts for at least one participant');
+                return;
+            }
+            
+            if (Math.abs(total - amount) > 0.01) {
+                e.preventDefault();
+                alert(`Custom split total ($${total.toFixed(2)}) must equal expense amount ($${amount.toFixed(2)})`);
+                return;
+            }
+        }
+    });
+});
+</script>
 {% endblock %}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from extensions import db
-from models import Expense, User
+from models import Expense, User, Group
 
 # === User Model Tests ===
 
@@ -153,3 +153,146 @@ def test_expense_requires_description(app):
         db.session.commit()
 
     db.session.rollback()
+
+
+# === Group Model Tests ===
+
+
+def test_group_create_and_persist(app):
+    """Test that Group model can be created and persisted to the database."""
+    # Arrange
+    group = Group(name="Team Alpha", members="Alice, Bob, Charlie")
+
+    # Act
+    db.session.add(group)
+    db.session.commit()
+
+    # Assert
+    stored = Group.query.first()
+    assert stored is not None
+    assert stored.name == "Team Alpha"
+    assert stored.members == "Alice, Bob, Charlie"
+
+
+def test_group_requires_name(app):
+    """Test that Group model raises IntegrityError when name is None."""
+    # Arrange
+    group = Group(name=None, members="Alice, Bob")
+    db.session.add(group)
+
+    # Act & Assert
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+
+    db.session.rollback()
+
+
+# === Expense-Group Relationship Tests ===
+
+
+def test_expense_group_relationship(app):
+    """Test that Expense can be associated with a Group."""
+    # Arrange
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+    
+    expense = Expense(
+        description="Lunch", 
+        amount=30.0, 
+        payer="Alice",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"Alice": 15.0, "Bob": 15.0}'
+    )
+
+    # Act
+    db.session.add(expense)
+    db.session.commit()
+
+    # Assert
+    stored_expense = Expense.query.first()
+    assert stored_expense.group_id == group.id
+    assert stored_expense.group == group
+    assert expense in group.expenses
+
+
+def test_expense_split_details_json_storage(app):
+    """Test that split_details can store and retrieve JSON data."""
+    # Arrange
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+    
+    split_details = {"Alice": 20.0, "Bob": 10.0}
+    expense = Expense(
+        description="Dinner", 
+        amount=30.0, 
+        payer="Alice",
+        group_id=group.id,
+        split_type="custom",
+        split_details='{"Alice": 20.0, "Bob": 10.0}'
+    )
+
+    # Act
+    db.session.add(expense)
+    db.session.commit()
+
+    # Assert
+    stored_expense = Expense.query.first()
+    assert stored_expense.split_details == '{"Alice": 20.0, "Bob": 10.0}'
+    assert stored_expense.split_type == "custom"
+
+
+def test_expense_default_split_type(app):
+    """Test that Expense defaults to 'equal' split_type."""
+    # Arrange
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+    
+    expense = Expense(
+        description="Lunch", 
+        amount=20.0, 
+        payer="Alice",
+        group_id=group.id
+    )
+
+    # Act
+    db.session.add(expense)
+    db.session.commit()
+
+    # Assert
+    stored_expense = Expense.query.first()
+    assert stored_expense.split_type == "equal"
+
+
+def test_group_expenses_backref(app):
+    """Test that Group.expenses backref works correctly."""
+    # Arrange
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+    
+    expense1 = Expense(
+        description="Lunch", 
+        amount=20.0, 
+        payer="Alice",
+        group_id=group.id
+    )
+    expense2 = Expense(
+        description="Dinner", 
+        amount=40.0, 
+        payer="Bob",
+        group_id=group.id
+    )
+
+    # Act
+    db.session.add_all([expense1, expense2])
+    db.session.commit()
+
+    # Assert
+    stored_group = Group.query.first()
+    assert len(stored_group.expenses) == 2
+    assert expense1 in stored_group.expenses
+    assert expense2 in stored_group.expenses

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -751,3 +751,273 @@ def test_balance_summary_filters_by_group(client, app):
     assert b"Bob" in response.data
     assert b"Charlie" not in response.data
     assert b"Dave" not in response.data
+
+def test_missing_description(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "",  # Missing
+        "amount": "100",
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["alice"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_missing_group(client):
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "100",
+        "payer": "alice",
+        "group_id": "",  # Missing
+        "split_type": "equal",
+        "participants": ["alice"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_missing_payer(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "100",
+        "payer": "",  # Missing
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["alice"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_invalid_amount_nonpositive(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "0",  # Or negative
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["alice"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_invalid_amount_type(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "abc",  # Not a number
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["alice"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_group_not_found(client):
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "50",
+        "payer": "alice",
+        "group_id": "99999",  # Nonexistent group
+        "split_type": "equal",
+        "participants": ["alice"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_payer_not_in_group(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "50",
+        "payer": "notamember",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["alice"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_no_participants_selected(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "100",
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": []  # Empty list
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_participant_not_in_group(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "100",
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["alice", "notamember"]
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_invalid_custom_amount(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    # Assume group members: alice, bob
+    data = {
+        "description": "Trip",
+        "amount": "100",
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "custom",
+        "custom_amount_alice": "abc",  # Invalid
+        "custom_amount_bob": "60"
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_no_custom_split_details(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    # No amounts for any member
+    data = {
+        "description": "Trip",
+        "amount": "100",
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "custom",
+        "custom_amount_alice": "",
+        "custom_amount_bob": ""
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0
+
+def test_invalid_custom_split_sum(client, app):
+    from extensions import db
+
+    group = Group(name="Fixture Group", members="alice, bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    data = {
+        "description": "Trip",
+        "amount": "90",
+        "payer": "alice",
+        "group_id": str(group.id),
+        "split_type": "custom",
+        "custom_amount_alice": "30",
+        "custom_amount_bob": "40"
+        # Adds up to 70, not 90
+    }
+    resp = client.post("/expense-splitter", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    assert Expense.query.count() == 0

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -186,9 +186,16 @@ def test_expense_splitter_get_returns_ok(client):
     assert response.status_code == 200
 
 
-def test_expense_splitter_post_creates_expense(client):
+def test_expense_splitter_post_creates_expense(client, app):
     """Test that POST /expense-splitter creates a new expense in the database."""
     # Arrange
+    from extensions import db
+    
+    # Create a group first
+    group = Group(name="Test Group", members="Alex, Sam, Jo")
+    db.session.add(group)
+    db.session.commit()
+    
     # Create a logged-in user session
     with client.session_transaction() as session:
         session["user_id"] = 1
@@ -198,7 +205,9 @@ def test_expense_splitter_post_creates_expense(client):
         "description": "Dinner",
         "amount": "36.75",
         "payer": "Alex",
-        "participants": "Alex, Sam, Jo",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["Alex", "Sam", "Jo"]
     }
 
     # Act
@@ -210,7 +219,8 @@ def test_expense_splitter_post_creates_expense(client):
     assert stored is not None
     assert stored.amount == 36.75
     assert stored.payer == "Alex"
-    assert stored.participants == "Alex, Sam, Jo"
+    assert stored.group_id == group.id
+    assert stored.split_type == "equal"
 
 
 def test_expense_splitter_rejects_invalid_amount(client):
@@ -375,3 +385,369 @@ def test_balance_summary_handles_expense_with_no_participants(client, app):
     # The orphan expense should be skipped, only the valid expense should be calculated
     assert b"Bob" in response.data
     assert b"Alice" in response.data
+
+
+# === New Group-Based Expense Tests ===
+
+
+def test_expense_splitter_requires_group_selection(client, app):
+    """Test that expense creation requires group selection."""
+    # Arrange
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "50.00",
+        "payer": "Alice",
+        "group_id": "",  # Empty group
+        "split_type": "equal",
+        "participants": ["Alice", "Bob"]
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect back to form
+    assert Expense.query.count() == 0
+
+
+def test_expense_splitter_rejects_zero_amount(client, app):
+    """Test that expense creation rejects zero amount."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "0.00",  # Zero amount
+        "payer": "Alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["Alice", "Bob"]
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect back to form
+    assert Expense.query.count() == 0
+
+
+def test_expense_splitter_rejects_negative_amount(client, app):
+    """Test that expense creation rejects negative amount."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "-10.00",  # Negative amount
+        "payer": "Alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["Alice", "Bob"]
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect back to form
+    assert Expense.query.count() == 0
+
+
+def test_expense_splitter_validates_payer_in_group(client, app):
+    """Test that payer must be a member of the selected group."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "50.00",
+        "payer": "Charlie",  # Not in group
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["Alice", "Bob"]
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect back to form
+    assert Expense.query.count() == 0
+
+
+def test_expense_splitter_validates_participants_in_group(client, app):
+    """Test that participants must be members of the selected group."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "50.00",
+        "payer": "Alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["Alice", "Charlie"]  # Charlie not in group
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect back to form
+    assert Expense.query.count() == 0
+
+
+def test_expense_splitter_creates_equal_split_expense(client, app):
+    """Test creating expense with equal split."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob, Charlie")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "60.00",
+        "payer": "Alice",
+        "group_id": str(group.id),
+        "split_type": "equal",
+        "participants": ["Alice", "Bob", "Charlie"]
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect after success
+    stored = Expense.query.first()
+    assert stored is not None
+    assert stored.description == "Dinner"
+    assert stored.amount == 60.0
+    assert stored.payer == "Alice"
+    assert stored.group_id == group.id
+    assert stored.split_type == "equal"
+    
+    # Check split details
+    import json
+    split_details = json.loads(stored.split_details)
+    assert split_details["Alice"] == 20.0
+    assert split_details["Bob"] == 20.0
+    assert split_details["Charlie"] == 20.0
+
+
+def test_expense_splitter_creates_custom_split_expense(client, app):
+    """Test creating expense with custom split."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob, Charlie")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "60.00",
+        "payer": "Alice",
+        "group_id": str(group.id),
+        "split_type": "custom",
+        "custom_amount_Alice": "30.00",
+        "custom_amount_Bob": "20.00",
+        "custom_amount_Charlie": "10.00"
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect after success
+    stored = Expense.query.first()
+    assert stored is not None
+    assert stored.split_type == "custom"
+    
+    # Check split details
+    import json
+    split_details = json.loads(stored.split_details)
+    assert split_details["Alice"] == 30.0
+    assert split_details["Bob"] == 20.0
+    assert split_details["Charlie"] == 10.0
+
+
+def test_expense_splitter_rejects_custom_split_mismatch(client, app):
+    """Test that custom split amounts must equal total amount."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "50.00",
+        "payer": "Alice",
+        "group_id": str(group.id),
+        "split_type": "custom",
+        "custom_amount_Alice": "30.00",
+        "custom_amount_Bob": "20.00"  # Total = 50, should be valid
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Should succeed
+    assert Expense.query.count() == 1
+
+
+def test_expense_splitter_rejects_custom_split_total_mismatch(client, app):
+    """Test that custom split with wrong total is rejected."""
+    # Arrange
+    from extensions import db
+    
+    group = Group(name="Test Group", members="Alice, Bob")
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    expense_data = {
+        "description": "Dinner",
+        "amount": "50.00",
+        "payer": "Alice",
+        "group_id": str(group.id),
+        "split_type": "custom",
+        "custom_amount_Alice": "30.00",
+        "custom_amount_Bob": "30.00"  # Total = 60, should be rejected
+    }
+
+    # Act
+    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect back to form
+    assert Expense.query.count() == 0
+
+
+def test_expense_splitter_filters_by_group(client, app):
+    """Test that expenses can be filtered by group."""
+    # Arrange
+    from extensions import db
+    
+    group1 = Group(name="Group 1", members="Alice, Bob")
+    group2 = Group(name="Group 2", members="Charlie, Dave")
+    db.session.add_all([group1, group2])
+    db.session.commit()
+
+    # Create expenses for both groups
+    expense1 = Expense(
+        description="Lunch 1", amount=20.0, payer="Alice", 
+        group_id=group1.id, split_type="equal", split_details='{"Alice": 10.0, "Bob": 10.0}'
+    )
+    expense2 = Expense(
+        description="Lunch 2", amount=40.0, payer="Charlie", 
+        group_id=group2.id, split_type="equal", split_details='{"Charlie": 20.0, "Dave": 20.0}'
+    )
+    db.session.add_all([expense1, expense2])
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    # Act
+    response = client.get(f"/expense-splitter?group_id={group1.id}")
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Lunch 1" in response.data
+    assert b"Lunch 2" not in response.data
+
+
+def test_balance_summary_filters_by_group(client, app):
+    """Test that balance summary can be filtered by group."""
+    # Arrange
+    from extensions import db
+    
+    group1 = Group(name="Group 1", members="Alice, Bob")
+    group2 = Group(name="Group 2", members="Charlie, Dave")
+    db.session.add_all([group1, group2])
+    db.session.commit()
+
+    # Create expenses for both groups
+    expense1 = Expense(
+        description="Lunch 1", amount=20.0, payer="Alice", 
+        group_id=group1.id, split_type="equal", split_details='{"Alice": 10.0, "Bob": 10.0}'
+    )
+    expense2 = Expense(
+        description="Lunch 2", amount=40.0, payer="Charlie", 
+        group_id=group2.id, split_type="equal", split_details='{"Charlie": 20.0, "Dave": 20.0}'
+    )
+    db.session.add_all([expense1, expense2])
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    # Act
+    response = client.get(f"/balance-summary?group_id={group1.id}")
+
+    # Assert
+    assert response.status_code == 200
+    # Should only show balances for Group 1 members
+    assert b"Alice" in response.data
+    assert b"Bob" in response.data
+    assert b"Charlie" not in response.data
+    assert b"Dave" not in response.data

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1021,3 +1021,41 @@ def test_invalid_custom_split_sum(client, app):
     resp = client.post("/expense-splitter", data=data, follow_redirects=False)
     assert resp.status_code == 302
     assert Expense.query.count() == 0
+
+
+# === Service Layer Coverage Tests (targeted lines) ===
+
+
+def test_expense_service_parse_split_details_json_error(app):
+    """Covers json.loads exception path (lines 133-134)."""
+    from services.expense_service import ExpenseService
+    from extensions import db
+
+    expense = Expense(
+        description="Test",
+        amount=10.0,
+        payer="Alice",
+        split_details="invalid json {",  # triggers JSONDecodeError
+    )
+    db.session.add(expense)
+    db.session.commit()
+
+    result = ExpenseService._parse_split_details(expense)
+    assert result == {}
+
+
+def test_expense_service_validate_custom_split_empty_details(app):
+    """Covers empty split_details early return (line 158)."""
+    from services.expense_service import ExpenseService
+
+    is_valid, error_msg = ExpenseService.validate_custom_split({}, 50.0)
+    assert not is_valid
+    assert error_msg == "No participants specified"
+
+
+def test_expense_service_calculate_equal_split_empty_participants(app):
+    """Covers empty participants early return (line 181)."""
+    from services.expense_service import ExpenseService
+
+    result = ExpenseService.calculate_equal_split([], 50.0)
+    assert result == {}


### PR DESCRIPTION
##  Feature: Group-Based Expense Splitting

### Overview
Implements group-based expense splitting with equal and custom split options, UI enhancements, and filtering by group.

###  Features
- Group association for expenses (`group_id`)
- Split types: `equal` or `custom` with `split_details` JSON
- UI: dynamic participant selection, custom amounts, live validation
- Filter expenses and balance summary by group

###  Technical
- models.py: add `group_id`, `split_type`, `split_details`, `group` relationship
- routes/expenses.py: validate inputs, compute splits, flash messages, filtering
- services/expense_service.py: equal/custom split, parsing, validation
- templates/apps/expense_splitter/index.html: new form and UX
- tests: expanded coverage for group-based scenarios


###  Tests
- Adds tests for group filtering, equal/custom splits, validation cases
- Backward compatibility maintained in service layer

