### PR TITLE
feat: implement group invitation system; auto-accept pending invitations on user signup; add tests for invitation creation and handling

### DIFF
--- a/models.py
+++ b/models.py
@@ -110,7 +110,7 @@ class GroupInvitation(db.Model):
     status = db.Column(
         db.String(20), nullable=False, default="pending"
     )  # 'pending', 'accepted', 'declined'
-    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc))
 
     # Relationships
     group = db.relationship("Group", backref="invitations")

--- a/models.py
+++ b/models.py
@@ -98,3 +98,23 @@ class Group(db.Model):
 
     def __repr__(self):
         return f"<Group {self.name}>"
+
+
+class GroupInvitation(db.Model):
+    """Model for tracking pending group invitations."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(200), nullable=False)
+    group_id = db.Column(db.Integer, db.ForeignKey("group.id"), nullable=False)
+    invited_by_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    status = db.Column(
+        db.String(20), nullable=False, default="pending"
+    )  # 'pending', 'accepted', 'declined'
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    # Relationships
+    group = db.relationship("Group", backref="invitations")
+    invited_by = db.relationship("User", foreign_keys=[invited_by_id])
+
+    def __repr__(self):
+        return f"<GroupInvitation {self.email} -> {self.group.name}>"

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -4,7 +4,7 @@ from flask import Blueprint, redirect, render_template, request, session, url_fo
 from flask_mail import Message
 
 from extensions import db, mail
-from models import User
+from models import GroupInvitation, User
 from services.auth_service import AuthService
 from utils.validators import is_valid_email
 
@@ -81,6 +81,16 @@ def verify_otp():
     # Clear OTP after successful verification
     user.otp = None
     user.otp_expiry = None
+
+    # Auto-accept any pending group invitations for this email
+    pending_invitations = GroupInvitation.query.filter_by(email=user.email, status="pending").all()
+    for invitation in pending_invitations:
+        # Add user to the group
+        if user not in invitation.group.members:
+            invitation.group.members.append(user)
+        # Mark invitation as accepted
+        invitation.status = "accepted"
+
     db.session.commit()
 
     # Create session

--- a/routes/groups.py
+++ b/routes/groups.py
@@ -60,6 +60,9 @@ def create_group():
         # Add creator as first member
         group.members.append(creator)
 
+        # Flush to get group.id for invitation creation
+        db.session.flush()
+
         # Add other members if emails provided
         if member_emails:
             emails = [email.strip() for email in member_emails.split(",") if email.strip()]

--- a/routes/groups.py
+++ b/routes/groups.py
@@ -60,7 +60,8 @@ def create_group():
         # Add creator as first member
         group.members.append(creator)
 
-        # Flush to get group.id for invitation creation
+        # Flush to assign group.id before checking for existing invitations
+        # The duplicate check query (lines 84-86) requires group.id to be set
         db.session.flush()
 
         # Add other members if emails provided

--- a/routes/groups.py
+++ b/routes/groups.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
 
 from extensions import db
-from models import Group, User
+from models import Group, GroupInvitation, User
+from services.notification_service import notify_group_invitation
 from utils.decorators import login_required
 from utils.validators import is_valid_email
 
@@ -67,15 +68,31 @@ def create_group():
                 if email == creator.email:
                     continue  # Skip creator (already added)
 
-                # Find or create user
+                # Find existing user
                 user = User.query.filter_by(email=email).first()
-                if not user:
-                    # Create placeholder user (they'll set display_name later)
-                    user = User(email=email)
-                    db.session.add(user)
 
-                if user not in group.members:
-                    group.members.append(user)
+                if user:
+                    # User exists - add them to the group
+                    if user not in group.members:
+                        group.members.append(user)
+                else:
+                    # User doesn't exist - create invitation
+                    # Check if invitation already exists
+                    existing_invitation = GroupInvitation.query.filter_by(
+                        email=email, group_id=group.id, status="pending"
+                    ).first()
+
+                    if not existing_invitation:
+                        invitation = GroupInvitation(
+                            email=email, group_id=group.id, invited_by_id=user_id
+                        )
+                        db.session.add(invitation)
+
+                        # Send invitation notification
+                        try:
+                            notify_group_invitation(creator.email, email, name)
+                        except Exception as e:
+                            print(f"Failed to send invitation notification: {e}")
 
         db.session.commit()
         flash(f"Group '{name}' created successfully!", "success")

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -42,3 +42,21 @@ def notify_expense_participants(expense, participant_emails):
         print(f"Subject: {subject}")
         print(f"\n{body}")
         print("=" * 60 + "\n")
+
+
+def notify_group_invitation(inviter_email, invitee_email, group_name):
+    """Print notification to terminal when a user is invited to a group."""
+    subject = f"You've been invited to join '{group_name}'"
+    body = (
+        f"{inviter_email} has invited you to join the group '{group_name}'.\n\n"
+        f"When you sign up or log in, you'll automatically be added to this group.\n"
+    )
+
+    # Print notification to terminal instead of sending email
+    print("\n" + "=" * 60)
+    print("GROUP INVITATION")
+    print("=" * 60)
+    print(f"To: {invitee_email}")
+    print(f"Subject: {subject}")
+    print(f"\n{body}")
+    print("=" * 60 + "\n")

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -153,6 +153,64 @@ def test_logout_clears_session(client, app):
     # Assert
     assert response.status_code == 302
     assert response.location == "/"
+    # Check session cleared
+    with client.session_transaction() as sess:
+        assert "user_id" not in sess
+        assert "user_email" not in sess
+
+
+def test_verify_otp_auto_accepts_pending_invitations(client, app):
+    """Test that verifying OTP auto-accepts pending group invitations."""
+    # Arrange
+    from datetime import datetime, timedelta, timezone
+
+    from extensions import db
+    from models import Group, GroupInvitation
+
+    # Create inviter and group
+    inviter = User(email="inviter@example.com")
+    db.session.add(inviter)
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=inviter.id)
+    group.members.append(inviter)
+    db.session.add(group)
+    db.session.commit()
+
+    # Create pending invitation for new user
+    invitation = GroupInvitation(
+        email="newuser@example.com", group_id=group.id, invited_by_id=inviter.id
+    )
+    db.session.add(invitation)
+    db.session.commit()
+
+    # Create new user with OTP (simulating signup)
+    new_user = User(email="newuser@example.com")
+    new_user.otp = "123456"
+    new_user.otp_expiry = datetime.now(timezone.utc) + timedelta(minutes=10)
+    db.session.add(new_user)
+    db.session.commit()
+
+    verify_data = {"email": "newuser@example.com", "otp": "123456"}
+
+    # Act
+    response = client.post("/auth/verify-otp", data=verify_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+
+    # Check user was added to group
+    db.session.refresh(group)
+    assert new_user in group.members
+
+    # Check invitation status updated
+    db.session.refresh(invitation)
+    assert invitation.status == "accepted"
+    response = client.get("/auth/logout", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+    assert response.location == "/"
     with client.session_transaction() as sess:
         assert "user_id" not in sess
         assert "user_email" not in sess

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -206,11 +206,3 @@ def test_verify_otp_auto_accepts_pending_invitations(client, app):
     # Check invitation status updated
     db.session.refresh(invitation)
     assert invitation.status == "accepted"
-    response = client.get("/auth/logout", follow_redirects=False)
-
-    # Assert
-    assert response.status_code == 302
-    assert response.location == "/"
-    with client.session_transaction() as sess:
-        assert "user_id" not in sess
-        assert "user_email" not in sess

--- a/tests/test_expense_routes.py
+++ b/tests/test_expense_routes.py
@@ -109,9 +109,10 @@ def test_groups_list_returns_ok(client, app):
 
 
 def test_groups_create_group_with_members(client, app):
-    """Test that POST /groups/create creates a new group with members."""
+    """Test that POST /groups/create creates invitations for non-existent members."""
     # Arrange
     from extensions import db
+    from models import GroupInvitation
 
     # Create the logged-in user (creator)
     creator = User(email="test@example.com")
@@ -134,10 +135,10 @@ def test_groups_create_group_with_members(client, app):
     assert response.status_code == 302
     stored = Group.query.filter_by(name="My Agile group").first()
     assert stored is not None
-    assert len(stored.members) == 4  # Creator + 3 members
+    assert len(stored.members) == 1  # Only creator (others are invited)
     assert creator in stored.members
-    # Check that member users were created
-    assert User.query.filter_by(email="anikait@example.com").first() is not None
+    # Check that invitations were created for non-existent users
+    assert GroupInvitation.query.filter_by(email="anikait@example.com").first() is not None
 
 
 def test_groups_create_group_rejects_invalid_member_emails(client, app):
@@ -226,9 +227,10 @@ def test_groups_create_group_requires_name(client, app):
 
 
 def test_groups_create_group_skips_duplicate_creator(client, app):
-    """Test that creator is not added twice if listed in members."""
+    """Test that creator is not added twice if listed in members, and creates invitation for new user."""
     # Arrange
     from extensions import db
+    from models import GroupInvitation
 
     creator = User(email="test@example.com")
     db.session.add(creator)
@@ -250,10 +252,12 @@ def test_groups_create_group_skips_duplicate_creator(client, app):
     assert response.status_code == 302
     group = Group.query.filter_by(name="Test Group").first()
     assert group is not None
-    # Creator should only be in members once, plus alice
+    # Creator should only be in members once
     creator_count = sum(1 for m in group.members if m.email == "test@example.com")
     assert creator_count == 1
-    assert len(group.members) == 2  # creator + alice
+    assert len(group.members) == 1  # Only creator (alice gets an invitation)
+    # Check invitation was created for alice
+    assert GroupInvitation.query.filter_by(email="alice@example.com").first() is not None
 
 
 def test_groups_list_requires_login(client):
@@ -1183,4 +1187,3 @@ def test_expense_splitter_displays_user_display_names(client, app):
     assert b"Bob Jones" in response.data
     # Emails should not be visible as standalone text (they're in email_to_name mapping)
     # Note: emails still exist in HTML attributes and data structures, so we check for display names
-

--- a/tests/test_group_invitations.py
+++ b/tests/test_group_invitations.py
@@ -1,0 +1,259 @@
+"""Tests for group invitation functionality."""
+
+from models import Group, GroupInvitation, User
+
+
+def test_group_invitation_model_creation(app):
+    """Test that GroupInvitation model can be created and persisted."""
+    from extensions import db
+
+    # Arrange
+    inviter = User(email="inviter@example.com")
+    db.session.add(inviter)
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=inviter.id)
+    db.session.add(group)
+    db.session.commit()
+
+    # Act
+    invitation = GroupInvitation(
+        email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+    )
+    db.session.add(invitation)
+    db.session.commit()
+
+    # Assert
+    stored_invitation = GroupInvitation.query.filter_by(email="invitee@example.com").first()
+    assert stored_invitation is not None
+    assert stored_invitation.email == "invitee@example.com"
+    assert stored_invitation.group_id == group.id
+    assert stored_invitation.invited_by_id == inviter.id
+    assert stored_invitation.status == "pending"
+
+
+def test_create_group_with_non_existent_member_creates_invitation(client, app):
+    """Test that creating a group with non-existent member email creates an invitation."""
+    from extensions import db
+
+    # Arrange - Create logged-in user
+    creator = User(email="creator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    # Act - Create group with non-existent member
+    group_data = {
+        "name": "Test Group",
+        "members": "existing@example.com, newuser@example.com",
+    }
+
+    # Pre-create existing user
+    existing_user = User(email="existing@example.com")
+    db.session.add(existing_user)
+    db.session.commit()
+
+    response = client.post("/groups/create", data=group_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+
+    # Check group was created
+    group = Group.query.filter_by(name="Test Group").first()
+    assert group is not None
+
+    # Check existing user was added to group
+    assert existing_user in group.members
+
+    # Check invitation was created for non-existent user
+    invitation = GroupInvitation.query.filter_by(email="newuser@example.com").first()
+    assert invitation is not None
+    assert invitation.group_id == group.id
+    assert invitation.invited_by_id == creator.id
+    assert invitation.status == "pending"
+
+
+def test_create_group_with_existing_members_no_invitation(client, app):
+    """Test that creating a group with all existing members does not create invitations."""
+    from extensions import db
+
+    # Arrange - Create users
+    creator = User(email="creator@example.com")
+    member1 = User(email="member1@example.com")
+    member2 = User(email="member2@example.com")
+    db.session.add_all([creator, member1, member2])
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    # Act - Create group with existing members
+    group_data = {
+        "name": "Existing Members Group",
+        "members": "member1@example.com, member2@example.com",
+    }
+
+    response = client.post("/groups/create", data=group_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+
+    # Check no invitations were created
+    invitations = GroupInvitation.query.all()
+    assert len(invitations) == 0
+
+    # Check all members were added
+    group = Group.query.filter_by(name="Existing Members Group").first()
+    assert len(group.members) == 3  # creator + 2 members
+
+
+def test_invitation_notification_is_sent(client, app, capsys):
+    """Test that notification is printed when invitation is created."""
+    from extensions import db
+
+    # Arrange
+    creator = User(email="creator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    # Act - Create group with non-existent member
+    group_data = {"name": "Notification Test", "members": "newuser@example.com"}
+
+    response = client.post("/groups/create", data=group_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+
+    # Check notification was printed
+    captured = capsys.readouterr()
+    assert "GROUP INVITATION" in captured.out
+    assert "newuser@example.com" in captured.out
+    assert "Notification Test" in captured.out
+
+
+def test_user_signup_accepts_pending_invitations(client, app):
+    """Test that when a user signs up, they auto-join groups with pending invitations."""
+    from extensions import db
+
+    # Arrange - Create group and invitation
+    inviter = User(email="inviter@example.com")
+    db.session.add(inviter)
+    db.session.commit()
+
+    group = Group(name="Auto Join Group", created_by_id=inviter.id)
+    group.members.append(inviter)
+    db.session.add(group)
+    db.session.commit()
+
+    invitation = GroupInvitation(
+        email="newuser@example.com", group_id=group.id, invited_by_id=inviter.id, status="pending"
+    )
+    db.session.add(invitation)
+    db.session.commit()
+
+    # Act - New user signs up with invited email
+    # Simulate OTP verification which creates the user
+    new_user = User(email="newuser@example.com")
+    db.session.add(new_user)
+    db.session.commit()
+
+    # Auto-accept invitations (this logic will be in auth routes)
+    pending_invitations = GroupInvitation.query.filter_by(
+        email=new_user.email, status="pending"
+    ).all()
+
+    for inv in pending_invitations:
+        inv.group.members.append(new_user)
+        inv.status = "accepted"
+
+    db.session.commit()
+
+    # Assert
+    assert new_user in group.members
+    updated_invitation = GroupInvitation.query.filter_by(email="newuser@example.com").first()
+    assert updated_invitation.status == "accepted"
+
+
+def test_duplicate_invitations_not_created(client, app):
+    """Test that duplicate invitations are not created for the same email and group."""
+    from extensions import db
+
+    # Arrange
+    creator = User(email="creator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    group = Group(name="Duplicate Test", created_by_id=creator.id)
+    group.members.append(creator)
+    db.session.add(group)
+    db.session.commit()
+
+    # Create first invitation manually
+    invitation1 = GroupInvitation(
+        email="invitee@example.com", group_id=group.id, invited_by_id=creator.id
+    )
+    db.session.add(invitation1)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    # Act - Try to create group again with same invitee (shouldn't create duplicate)
+    # This tests the logic in the route
+    invitations_before = GroupInvitation.query.filter_by(email="invitee@example.com").count()
+
+    # Simulate checking for existing invitation before creating
+    existing = GroupInvitation.query.filter_by(
+        email="invitee@example.com", group_id=group.id, status="pending"
+    ).first()
+
+    if not existing:
+        invitation2 = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=creator.id
+        )
+        db.session.add(invitation2)
+        db.session.commit()
+
+    invitations_after = GroupInvitation.query.filter_by(email="invitee@example.com").count()
+
+    # Assert - No duplicate created
+    assert invitations_before == invitations_after
+
+
+def test_invalid_email_does_not_create_invitation(client, app):
+    """Test that invalid email format does not create invitation."""
+    from extensions import db
+
+    # Arrange
+    creator = User(email="creator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    # Act - Try to create group with invalid email
+    group_data = {"name": "Invalid Email Group", "members": "validemail@example.com, notanemail"}
+
+    response = client.post("/groups/create", data=group_data, follow_redirects=True)
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Invalid email format" in response.data
+
+    # No group or invitations should be created
+    group = Group.query.filter_by(name="Invalid Email Group").first()
+    assert group is None
+
+    invitations = GroupInvitation.query.all()
+    assert len(invitations) == 0

--- a/tests/test_group_invitations.py
+++ b/tests/test_group_invitations.py
@@ -154,7 +154,7 @@ def test_user_signup_accepts_pending_invitations(client, app):
     db.session.commit()
 
     invitation = GroupInvitation(
-        email="newuser@example.com", group_id=group.id, invited_by_id=inviter.id, status="pending"
+        email="newuser@example.com", group_id=group.id, invited_by_id=inviter.id
     )
     db.session.add(invitation)
     db.session.commit()
@@ -257,3 +257,82 @@ def test_invalid_email_does_not_create_invitation(client, app):
 
     invitations = GroupInvitation.query.all()
     assert len(invitations) == 0
+
+
+def test_notification_failure_does_not_stop_invitation_creation(client, app, monkeypatch):
+    """Test that notification failure doesn't prevent invitation from being created."""
+    from extensions import db
+
+    # Arrange
+    creator = User(email="creator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    # Mock notification to raise exception
+    def mock_notify_error(*args, **kwargs):
+        raise Exception("Email service down")
+
+    monkeypatch.setattr("routes.groups.notify_group_invitation", mock_notify_error)
+
+    # Act - Create group with non-existent member
+    group_data = {"name": "Notification Error Group", "members": "newuser@example.com"}
+
+    response = client.post("/groups/create", data=group_data, follow_redirects=False)
+
+    # Assert - Invitation should still be created despite notification failure
+    assert response.status_code == 302
+
+    invitation = GroupInvitation.query.filter_by(email="newuser@example.com").first()
+    assert invitation is not None
+    assert invitation.status == "pending"
+
+    group = Group.query.filter_by(name="Notification Error Group").first()
+    assert group is not None
+
+
+def test_user_already_in_group_when_accepting_invitation(client, app):
+    """Test that auto-accept handles case where user is already in group (edge case)."""
+    from extensions import db
+
+    # Arrange - Create group with invitation
+    inviter = User(email="inviter@example.com")
+    new_user = User(email="newuser@example.com")
+    db.session.add_all([inviter, new_user])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=inviter.id)
+    group.members.extend([inviter, new_user])  # User already in group
+    db.session.add(group)
+    db.session.commit()
+
+    # Create pending invitation for user already in group (edge case)
+    invitation = GroupInvitation(
+        email="newuser@example.com", group_id=group.id, invited_by_id=inviter.id
+    )
+    db.session.add(invitation)
+    db.session.commit()
+
+    # Act - Simulate auto-accept logic from verify_otp
+    pending_invitations = GroupInvitation.query.filter_by(
+        email=new_user.email, status="pending"
+    ).all()
+
+    for inv in pending_invitations:
+        # This should handle the case where user is already in group
+        if new_user not in inv.group.members:
+            inv.group.members.append(new_user)
+        inv.status = "accepted"
+
+    db.session.commit()
+
+    # Assert - Invitation marked as accepted, no duplicate membership
+    updated_invitation = GroupInvitation.query.filter_by(email="newuser@example.com").first()
+    assert updated_invitation.status == "accepted"
+
+    # User should appear only once in members
+    member_count = sum(1 for m in group.members if m.email == "newuser@example.com")
+    assert member_count == 1

--- a/tests/test_group_routes.py
+++ b/tests/test_group_routes.py
@@ -24,9 +24,10 @@ def test_groups_list_returns_ok(client, app):
 
 
 def test_groups_create_group_with_members(client, app):
-    """Test that POST /groups/create creates a new group with members."""
+    """Test that POST /groups/create creates invitations for non-existent members."""
     # Arrange
     from extensions import db
+    from models import GroupInvitation
 
     # Create the logged-in user (creator)
     creator = User(email="test@example.com")
@@ -49,10 +50,12 @@ def test_groups_create_group_with_members(client, app):
     assert response.status_code == 302
     stored = Group.query.filter_by(name="My Agile group").first()
     assert stored is not None
-    assert len(stored.members) == 4  # Creator + 3 members
+    assert len(stored.members) == 1  # Only creator (others are invited)
     assert creator in stored.members
-    # Check that member users were created
-    assert User.query.filter_by(email="anikait@example.com").first() is not None
+    # Check that invitations were created for non-existent users
+    assert GroupInvitation.query.filter_by(email="anikait@example.com").first() is not None
+    assert GroupInvitation.query.filter_by(email="sairithik@example.com").first() is not None
+    assert GroupInvitation.query.filter_by(email="pradhyumna@example.com").first() is not None
 
 
 def test_groups_create_group_rejects_invalid_member_emails(client, app):
@@ -141,9 +144,10 @@ def test_groups_create_group_requires_name(client, app):
 
 
 def test_groups_create_group_skips_duplicate_creator(client, app):
-    """Test that creator is not added twice if listed in members."""
+    """Test that creator is not added twice if listed in members, and creates invitation for new user."""
     # Arrange
     from extensions import db
+    from models import GroupInvitation
 
     creator = User(email="test@example.com")
     db.session.add(creator)
@@ -165,10 +169,12 @@ def test_groups_create_group_skips_duplicate_creator(client, app):
     assert response.status_code == 302
     group = Group.query.filter_by(name="Test Group").first()
     assert group is not None
-    # Creator should only be in members once, plus alice
+    # Creator should only be in members once
     creator_count = sum(1 for m in group.members if m.email == "test@example.com")
     assert creator_count == 1
-    assert len(group.members) == 2  # creator + alice
+    assert len(group.members) == 1  # Only creator (alice gets an invitation)
+    # Check invitation was created for alice
+    assert GroupInvitation.query.filter_by(email="alice@example.com").first() is not None
 
 
 def test_groups_list_requires_login(client):
@@ -178,3 +184,32 @@ def test_groups_list_requires_login(client):
 
     # Assert - should redirect to login
     assert response.status_code == 302
+
+
+def test_groups_create_handles_database_error(client, app, monkeypatch):
+    """Test that POST /groups/create handles database errors gracefully."""
+    # Arrange
+    from extensions import db
+
+    creator = User(email="test@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    # Simulate database error during commit
+    def mock_commit():
+        raise Exception("Database error")
+
+    monkeypatch.setattr(db.session, "commit", mock_commit)
+
+    group_data = {"name": "Test Group", "members": "member@example.com"}
+
+    # Act
+    response = client.post("/groups/create", data=group_data, follow_redirects=True)
+
+    # Assert - should redirect with error message
+    assert response.status_code == 200
+    assert b"Failed to create group" in response.data


### PR DESCRIPTION
## 📋 Description
Invite User to a group and auto add them once they sign up with the application

## 🎯 Changes Made
- Added `GroupInvitation` model to track pending invitations
- Modified group creation to send invitations for non-existent users
- Added auto-accept logic when invited users sign up
- Created console notification for group invitations

## 🧪 Testing
- [x] All tests pass (`uv run pytest -v`)
- [x] Coverage meets requirements (85%+ per file, 90%+ overall)
- [x] Added 7 new tests in `test_group_invitations.py`
- [x] Updated existing tests to match new behavior

## 🔗 Related Issue
Closes #29 

## 📸 Screenshots

User invite on the console:

<img width="675" height="252" alt="Screenshot 2025-10-27 161622" src="https://github.com/user-attachments/assets/54637dcc-5cc0-4e6b-9f72-be493f59b8e2" />

Since the invited user hasn't signed up yet, we don't see their email in the member list:

<img width="733" height="242" alt="Screenshot 2025-10-27 161632" src="https://github.com/user-attachments/assets/8fe1e64b-2c74-45c2-9bf3-c79863252f23" />

After signing up, their email is displayed:

<img width="740" height="264" alt="Screenshot 2025-10-27 161730" src="https://github.com/user-attachments/assets/8980da2b-1bd2-4747-a37d-41d50528f07e" />


<img width="768" height="708" alt="Screenshot 2025-10-27 161754" src="https://github.com/user-attachments/assets/c19b9846-00c3-4bb2-9447-506854181ede" />


## 🔄 Files Changed
- `models.py` - Added GroupInvitation model
- `routes/groups.py` - Modified create_group() for invitations
- `routes/auth.py` - Added auto-accept on signup
- `services/notification_service.py` - Added notify_group_invitation()
- `tests/test_group_invitations.py` - New test file (7 tests)
- `tests/test_group_routes.py` - Updated existing tests
- `tests/test_expense_routes.py` - Updated existing tests

## 📝 Notes
- Changed from auto-creating users to invitation system
- Invited users cannot be in expenses until they sign up
- Duplicate invitations are prevented
- Email validation done before creating invitations