### PR TITLE
refactored UI

### DIFF
--- a/routes/expenses.py
+++ b/routes/expenses.py
@@ -16,7 +16,15 @@ expenses_bp = Blueprint("expenses", __name__)
 @expenses_bp.route("/expense-splitter", methods=["GET", "POST"])
 @login_required
 def expense_splitter():
-    """Handle expense splitter page - create and view expenses."""
+    """Redirect to groups list - expenses are now group-specific."""
+    # Redirect to groups list since expenses are now group-scoped
+    return redirect(url_for("groups.list_groups"))
+
+
+@expenses_bp.route("/expense-splitter-old", methods=["GET", "POST"])
+@login_required
+def expense_splitter_old():
+    """Old expense splitter - kept for reference but redirects."""
     # Get all groups for the form
     groups = Group.query.all()
 

--- a/routes/groups.py
+++ b/routes/groups.py
@@ -1,8 +1,11 @@
+import json
+
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
 
 from extensions import db
-from models import Group, GroupInvitation, User
-from services.notification_service import notify_group_invitation
+from models import Expense, Group, GroupInvitation, User
+from services.expense_service import ExpenseService
+from services.notification_service import notify_expense_participants, notify_group_invitation
 from utils.decorators import login_required
 from utils.validators import is_valid_email
 
@@ -25,18 +28,10 @@ def list_groups():
     return render_template("groups/index.html", groups=groups)
 
 
-@groups_bp.route("/create", methods=["POST"])
+@groups_bp.route("/create", methods=["GET", "POST"])
 @login_required
 def create_group():
-    """Create a new group and add the creator as the first member."""
-    name = request.form.get("name", "").strip()
-    member_emails = request.form.get("members", "").strip()
-
-    # Validate inputs
-    if not name:
-        flash("Group name is required.", "error")
-        return redirect(url_for("groups.list_groups"))
-
+    """Display create group form (GET) or create a new group (POST)."""
     user_id = session.get("user_id")
     creator = db.session.get(User, user_id)
 
@@ -44,13 +39,26 @@ def create_group():
         flash("User not found", "error")
         return redirect(url_for("groups.list_groups"))
 
+    if request.method == "GET":
+        """Display the create group form."""
+        return render_template("groups/create.html")
+
+    # POST - Create a new group
+    name = request.form.get("name", "").strip()
+    member_emails = request.form.get("members", "").strip()
+
+    # Validate inputs
+    if not name:
+        flash("Group name is required.", "error")
+        return redirect(url_for("groups.create_group"))
+
     # Validate all email formats BEFORE any DB operations
     if member_emails:
         emails = [email.strip() for email in member_emails.split(",") if email.strip()]
         for email in emails:
             if not is_valid_email(email):
                 flash(f"Invalid email format: {email}", "error")
-                return redirect(url_for("groups.list_groups"))
+                return redirect(url_for("groups.create_group"))
 
     try:
         # Create the group
@@ -103,6 +111,193 @@ def create_group():
     except Exception as e:
         db.session.rollback()
         flash(f"Failed to create group: {str(e)}", "error")
-        return redirect(url_for("groups.list_groups"))
+        return redirect(url_for("groups.create_group"))
 
     return redirect(url_for("groups.list_groups"))
+
+
+@groups_bp.route("/<int:group_id>", methods=["GET", "POST"])
+@login_required
+def group_expenses(group_id):
+    """Display or create expenses for a specific group."""
+    user_id = session.get("user_id")
+    user = db.session.get(User, user_id)
+
+    if not user:
+        flash("User not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    # Get the group and verify user is a member
+    group = db.session.get(Group, group_id)
+    if not group:
+        flash("Group not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    if user not in group.members:
+        flash("You are not a member of this group", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    # POST - Create expense
+    if request.method == "POST":
+        # Extract form data
+        description = request.form.get("description", "").strip()
+        amount_raw = request.form.get("amount", "").strip()
+        payer = request.form.get("payer", "").strip()
+        split_type = request.form.get("split_type", "equal").strip()
+
+        # Validate required fields
+        if not description:
+            flash("Description is required", "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        if not payer:
+            flash("Payer is required", "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        # Validate amount
+        try:
+            amount = float(amount_raw)
+            if amount <= 0:
+                flash("Amount must be greater than zero", "error")
+                return redirect(url_for("groups.group_expenses", group_id=group_id))
+        except (ValueError, TypeError):
+            flash("Please enter a valid amount", "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        # Get group member emails for validation
+        group_member_emails = [member.email for member in group.members]
+
+        # Validate payer is in group
+        if payer not in group_member_emails:
+            flash("Payer must be a member of the group", "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        # Handle participants and split details
+        if split_type == "equal":
+            # Get selected participants for equal split
+            selected_participants = request.form.getlist("participants")
+            if not selected_participants:
+                flash("Please select at least one participant", "error")
+                return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+            # Validate all participants are in group
+            for participant in selected_participants:
+                if participant not in group_member_emails:
+                    flash(f"Participant '{participant}' is not in the group", "error")
+                    return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+            # Calculate equal split
+            split_details = ExpenseService.calculate_equal_split(selected_participants, amount)
+
+        else:  # custom split
+            # Get custom split amounts
+            split_details = {}
+            for member_email in group_member_emails:
+                amount_key = f"custom_amount_{member_email}"
+                custom_amount = request.form.get(amount_key, "").strip()
+                if custom_amount:
+                    try:
+                        split_details[member_email] = float(custom_amount)
+                    except ValueError:
+                        flash(f"Invalid amount for {member_email}", "error")
+                        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+            if not split_details:
+                flash("Please specify amounts for at least one participant", "error")
+                return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+            # Validate custom split
+            is_valid, error_msg = ExpenseService.validate_custom_split(split_details, amount)
+            if not is_valid:
+                flash(error_msg, "error")
+                return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        # Create expense
+        expense = Expense(
+            description=description,
+            amount=amount,
+            payer=payer,
+            group_id=group_id,
+            split_type=split_type,
+            split_details=json.dumps(split_details),
+            participants=", ".join(split_details.keys()),  # Keep for backward compatibility
+        )
+        db.session.add(expense)
+        db.session.commit()
+
+        # Send email notifications to participants (excluding the payer)
+        participant_list = [email for email in split_details.keys() if email != payer]
+        if participant_list:
+            try:
+                notify_expense_participants(expense, participant_list)
+                print(f"Sent notifications to: {participant_list}")
+            except Exception as e:
+                print(f"Failed to send notifications: {e}")
+
+        flash("Expense added successfully!", "success")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # GET request - show expenses for this group
+    expenses = Expense.query.filter_by(group_id=group_id).order_by(Expense.created_at.desc()).all()
+
+    # Process expenses for display
+    expense_views = []
+    all_emails = set()
+    for expense in expenses:
+        split_details = ExpenseService._parse_split_details(expense)
+        participants = list(split_details.keys())
+        share = (
+            list(split_details.values())[0]
+            if len(split_details) == 1 and expense.split_type == "equal"
+            else None
+        )
+        expense_views.append(
+            {
+                "model": expense,
+                "participants": participants,
+                "share": share,
+                "split_details": split_details,
+            }
+        )
+        # Collect all emails for display name lookup
+        all_emails.add(expense.payer)
+        all_emails.update(participants)
+
+    # Bulk fetch all users for the emails to avoid N+1 queries
+    if all_emails:
+        users = User.query.filter(User.email.in_(all_emails)).all()
+        user_map = {user.email: user for user in users}
+    else:
+        users = []
+        user_map = {}
+
+    email_to_name = {}
+    for email in all_emails:
+        user = user_map.get(email)
+        if user:
+            email_to_name[email] = user.display_name or user.email
+        else:
+            email_to_name[email] = email  # Fallback to email if user not found
+
+    # Convert group members to JSON-serializable format
+    groups_data = [
+        {
+            "id": group.id,
+            "name": group.name,
+            "members": [
+                {
+                    "email": m.email,
+                    "display_name": m.display_name or m.email,
+                }
+                for m in group.members
+            ],
+        }
+    ]
+
+    return render_template(
+        "groups/expenses.html",
+        group=group,
+        expenses=expense_views,
+        groups_data=groups_data,
+        email_to_name=email_to_name,
+    )

--- a/templates/groups/create.html
+++ b/templates/groups/create.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+
+{% block title %}Create Group • TeamSync{% endblock %}
+
+{% block extra_head %}
+<style>
+    @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+    }
+    .pulse-animation {
+        animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="mb-8">
+    <div class="flex items-center gap-4 mb-4">
+        <a href="{{ url_for('groups.list_groups') }}" class="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+            <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+            </svg>
+        </a>
+        <div class="p-3 bg-gradient-to-br from-emerald-500 to-teal-600 rounded-xl text-white">
+            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+            </svg>
+        </div>
+        <div>
+            <h2 class="text-3xl font-bold text-gray-900">Create New Group</h2>
+            <p class="text-gray-600">Organize your teams seamlessly</p>
+        </div>
+    </div>
+</div>
+
+<!-- Flash Messages -->
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <div class="mb-6">
+            {% for category, message in messages %}
+                <div class="p-4 rounded-lg {% if category == 'error' %}bg-red-100 text-red-700 border border-red-200{% elif category == 'success' %}bg-green-100 text-green-700 border border-green-200{% else %}bg-blue-100 text-blue-700 border border-blue-200{% endif %}">
+                    <div class="flex items-center gap-2">
+                        {% if category == 'error' %}
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                        {% elif category == 'success' %}
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                        {% endif %}
+                        <span class="font-medium">{{ message }}</span>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endwith %}
+
+<div class="max-w-2xl mx-auto">
+    <div class="bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl shadow-xl border border-cyan-500/20 p-6 text-white">
+        <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center gap-2">
+                <span class="text-xl">⚡</span>
+                <h3 class="text-lg font-semibold">New Group</h3>
+            </div>
+            <span class="text-xs font-mono text-cyan-400 bg-cyan-400/10 px-3 py-1 rounded-full border border-cyan-400/20">
+                TERMINAL.GROUP.ADD
+            </span>
+        </div>
+
+        <form method="POST" action="{{ url_for('groups.create_group') }}" class="space-y-4">
+            <div>
+                <label for="name" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Group Name</label>
+                <input type="text" id="name" name="name"
+                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
+                    placeholder="Team Alpha, Project X..." required>
+            </div>
+
+            <div>
+                <label for="members" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Additional Member Emails (Optional)</label>
+                <textarea id="members" name="members"
+                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
+                    placeholder="alice@example.com, bob@example.com" rows="4"></textarea>
+                <span class="text-xs text-gray-400 mt-1">Comma-separated email addresses. You (the creator) will be added automatically.</span>
+            </div>
+
+            <div class="flex gap-3 pt-4">
+                <button type="submit"
+                    class="flex-1 bg-gradient-to-r from-cyan-500 to-teal-500 text-slate-900 py-3 rounded-lg font-bold hover:from-cyan-400 hover:to-teal-400 transform hover:scale-[1.02] transition-all duration-200 shadow-lg uppercase tracking-wider flex items-center justify-center gap-2">
+                    <span class="text-xl">+</span>
+                    CREATE GROUP
+                </button>
+                <a href="{{ url_for('groups.list_groups') }}"
+                    class="px-6 py-3 bg-slate-700 text-white rounded-lg font-semibold hover:bg-slate-600 transform hover:scale-[1.02] transition-all duration-200 flex items-center justify-center">
+                    Cancel
+                </a>
+            </div>
+        </form>
+    </div>
+
+    <div class="mt-8 bg-gradient-to-r from-emerald-600 to-teal-600 rounded-xl p-6 text-white">
+        <div class="max-w-3xl mx-auto text-center">
+            <h3 class="text-xl font-bold mb-2">Pro Tip</h3>
+            <p class="opacity-90">Organize teams efficiently! Clear group structures boost productivity by 28% in collaborative projects.</p>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/groups/expenses.html
+++ b/templates/groups/expenses.html
@@ -1,0 +1,444 @@
+{% extends "base.html" %}
+
+{% block title %}{{ group.name }} Expenses • TeamSync{% endblock %}
+
+{% block extra_head %}
+<style>
+    @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+    }
+    .pulse-animation {
+        animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    }
+    @keyframes typing {
+        from { width: 0 }
+        to { width: 100% }
+    }
+    .typing-animation {
+        overflow: hidden;
+        white-space: nowrap;
+        animation: typing 2s steps(30, end);
+    }
+    .split-option {
+        display: none;
+    }
+    .split-option.active {
+        display: block;
+    }
+    .member-checkbox {
+        display: none;
+    }
+    .member-checkbox.active {
+        display: block;
+    }
+    .custom-amount {
+        display: none;
+    }
+    .custom-amount.active {
+        display: block;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="mb-8">
+    <div class="flex items-center gap-4 mb-4">
+        <a href="{{ url_for('groups.list_groups') }}" class="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+            <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+            </svg>
+        </a>
+        <div class="p-3 bg-gradient-to-br from-emerald-500 to-teal-600 rounded-xl text-white">
+            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+        </div>
+        <div>
+            <h2 class="text-3xl font-bold text-gray-900">{{ group.name }}</h2>
+            <p class="text-gray-600">Group expenses and transactions</p>
+        </div>
+    </div>
+</div>
+
+<!-- Flash Messages -->
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <div class="mb-6">
+            {% for category, message in messages %}
+                <div class="p-4 rounded-lg {% if category == 'error' %}bg-red-100 text-red-700 border border-red-200{% elif category == 'success' %}bg-green-100 text-green-700 border border-green-200{% else %}bg-blue-100 text-blue-700 border border-blue-200{% endif %}">
+                    {{ message }}
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endwith %}
+
+<div class="bg-gradient-to-r from-emerald-50 to-teal-50 rounded-xl p-6 mb-8 border border-emerald-200">
+    <div class="flex items-start gap-3">
+        <span class="text-2xl">💡</span>
+        <div class="flex-1">
+            <h3 class="font-semibold text-gray-900 mb-1">Tech-Forward Finance</h3>
+            <p class="text-gray-600 text-sm">A sleek, professional expense tracker with a modern tech aesthetic. Perfect for hackathons, team projects, or any group financial management.</p>
+        </div>
+        <a href="{{ url_for('expenses.balance_summary', group_id=group.id) }}" class="px-4 py-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-lg hover:from-blue-700 hover:to-indigo-700 transition-all duration-200 font-medium whitespace-nowrap flex items-center gap-2">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
+            </svg>
+            View Balance
+        </a>
+    </div>
+</div>
+
+<div class="grid lg:grid-cols-2 gap-8">
+    <div class="bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl shadow-xl border border-cyan-500/20 p-6 text-white">
+        <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center gap-2">
+                <span class="text-xl">⚡</span>
+                <h3 class="text-lg font-semibold">New Transaction</h3>
+            </div>
+            <span class="text-xs font-mono text-cyan-400 bg-cyan-400/10 px-3 py-1 rounded-full border border-cyan-400/20">
+                TERMINAL.EXPENSE.ADD
+            </span>
+        </div>
+
+        <form method="POST" action="{{ url_for('groups.group_expenses', group_id=group.id) }}" class="space-y-4" id="expenseForm">
+            <input type="hidden" name="group_id" value="{{ group.id }}">
+
+            <!-- Description -->
+            <div>
+                <label for="description" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Description *</label>
+                <input type="text" id="description" name="description"
+                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
+                    placeholder="Project supplies, Team lunch..." required>
+            </div>
+
+            <!-- Amount and Payer -->
+            <div class="grid grid-cols-2 gap-4">
+                <div>
+                    <label for="amount" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Amount ($) *</label>
+                    <input type="number" id="amount" name="amount" step="0.01" min="0.01"
+                        class="w-full px-4 py-3 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-2xl font-bold text-cyan-300 placeholder-gray-500"
+                        placeholder="0.00" required>
+                </div>
+                <div>
+                    <label for="payer" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Paid By *</label>
+                    <select id="payer" name="payer" required
+                        class="w-full px-4 py-3 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white">
+                        <option value="">Select payer...</option>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Split Type -->
+            <div>
+                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Split Type *</label>
+                <div class="flex gap-4">
+                    <label class="flex items-center">
+                        <input type="radio" name="split_type" value="equal" checked class="mr-2">
+                        <span class="text-sm">Equal Split</span>
+                    </label>
+                    <label class="flex items-center">
+                        <input type="radio" name="split_type" value="custom" class="mr-2">
+                        <span class="text-sm">Custom Split</span>
+                    </label>
+                </div>
+            </div>
+
+            <!-- Participants Selection (Equal Split) -->
+            <div id="equalSplitOptions" class="split-option active">
+                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Participants *</label>
+                <div id="participantsList" class="space-y-2">
+                    <p class="text-sm text-gray-400">Select a group first to see members</p>
+                </div>
+                <div id="equalSplitSummary" class="mt-2 text-sm text-cyan-300" style="display: none;">
+                    <span id="splitAmount">$0.00</span> per person
+                </div>
+            </div>
+
+            <!-- Custom Split Options -->
+            <div id="customSplitOptions" class="split-option">
+                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Custom Amounts *</label>
+                <div id="customAmountsList" class="space-y-2">
+                    <p class="text-sm text-gray-400">Select a group first to see members</p>
+                </div>
+                <div id="customSplitSummary" class="mt-2 text-sm text-cyan-300" style="display: none;">
+                    Total: $<span id="customTotal">0.00</span> / $<span id="customExpected">0.00</span>
+                </div>
+            </div>
+
+            <button type="submit"
+                class="w-full bg-gradient-to-r from-cyan-500 to-teal-500 text-slate-900 py-3 rounded-lg font-bold hover:from-cyan-400 hover:to-teal-400 transform hover:scale-[1.02] transition-all duration-200 shadow-lg uppercase tracking-wider flex items-center justify-center gap-2">
+                <span class="text-xl">+</span>
+                COMMIT TRANSACTION
+            </button>
+        </form>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center gap-2">
+                <span class="text-xl">📊</span>
+                <h3 class="text-lg font-semibold text-gray-900">Transaction Log</h3>
+            </div>
+            <span class="text-xs font-mono text-emerald-600 bg-emerald-100 px-3 py-1 rounded-full pulse-animation">
+                BALANCE: CALCULATING...
+            </span>
+        </div>
+
+        {% if expenses %}
+            <div class="space-y-3 max-h-96 overflow-y-auto">
+                {% for item in expenses %}
+                    {% set expense = item.model %}
+                <div class="group relative bg-gradient-to-r from-slate-50 to-gray-50 rounded-xl border border-gray-200 p-4 hover:shadow-md transition-all duration-200">
+                    <span class="absolute -top-2 right-4 text-xs font-mono font-bold bg-gradient-to-r from-cyan-500 to-teal-500 text-white px-2 py-1 rounded">
+                        #{{ loop.index }}
+                    </span>
+
+                    <div class="flex items-start justify-between mb-3">
+                        <div>
+                            <h4 class="font-semibold text-gray-900">{{ expense.description }}</h4>
+                            <div class="flex items-center gap-2 mt-1">
+                                <span class="text-xs font-mono bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded">
+                                    @{{ email_to_name.get(expense.payer, expense.payer) }}
+                                </span>
+                                <span class="text-xs text-gray-400 font-mono">
+                                    {{ expense.created_at.strftime('%Y-%m-%d %H:%M') }}
+                                </span>
+                            </div>
+                        </div>
+                        <div class="text-right">
+                            <span class="text-2xl font-bold font-mono text-emerald-600">
+                                ${{ '%.2f' % expense.amount }}
+                            </span>
+                        </div>
+                    </div>
+
+                    {% if item.participants %}
+                        <div class="border-t border-gray-200 pt-3">
+                            <div class="flex items-center justify-between">
+                                <div class="flex flex-wrap gap-1">
+                                    {% for p in item.participants %}
+                                        <span class="text-xs font-mono bg-cyan-100 text-cyan-700 px-2 py-0.5 rounded">
+                                            @{{ email_to_name.get(p, p) }}
+                                        </span>
+                                    {% endfor %}
+                                </div>
+                                {% if item.split_details %}
+                                    <div class="text-sm font-mono text-gray-600">
+                                        {% for participant, amount in item.split_details.items() %}
+                                            <span class="block">{{ email_to_name.get(participant, participant) }}: ${{ '%.2f' % amount }}</span>
+                                        {% endfor %}
+                                    </div>
+                                {% elif item.share is not none %}
+                                    <span class="text-sm font-mono text-gray-600">
+                                        Each: <span class="font-bold text-cyan-600">${{ '%.2f' % item.share }}</span>
+                                    </span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% else %}
+                        <div class="border-t border-gray-200 pt-3">
+                            <span class="text-xs font-mono text-gray-400">[NO SPLIT DEFINED]</span>
+                        </div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="text-center py-12">
+                <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-emerald-100 to-teal-100 rounded-full mb-4">
+                    <span class="text-2xl font-mono text-emerald-600">></span>
+                    <span class="text-2xl font-mono text-emerald-600 pulse-animation">_</span>
+                </div>
+                <p class="text-gray-500 font-mono mb-2">AWAITING FIRST TRANSACTION...</p>
+                <p class="text-sm text-gray-400">Initialize the expense log by adding your first transaction above.</p>
+            </div>
+        {% endif %}
+    </div>
+</div>
+
+<div class="mt-8 bg-gradient-to-r from-emerald-600 to-teal-600 rounded-xl p-8 text-white">
+    <div class="max-w-3xl mx-auto text-center">
+        <h3 class="text-2xl font-bold mb-2">Pro Tip</h3>
+        <p class="opacity-90">Split expenses fairly! Studies show that transparent expense tracking improves team collaboration by 35%.</p>
+    </div>
+</div>
+
+<script>
+// Group data for JavaScript
+const groups = JSON.parse('{{ groups_data|tojson|safe }}') || [];
+
+document.addEventListener('DOMContentLoaded', function() {
+    const payerSelect = document.getElementById('payer');
+    const amountInput = document.getElementById('amount');
+    const splitTypeRadios = document.querySelectorAll('input[name="split_type"]');
+    const equalSplitOptions = document.getElementById('equalSplitOptions');
+    const customSplitOptions = document.getElementById('customSplitOptions');
+    const participantsList = document.getElementById('participantsList');
+    const customAmountsList = document.getElementById('customAmountsList');
+    const equalSplitSummary = document.getElementById('equalSplitSummary');
+    const customSplitSummary = document.getElementById('customSplitSummary');
+    const splitAmount = document.getElementById('splitAmount');
+    const customTotal = document.getElementById('customTotal');
+    const customExpected = document.getElementById('customExpected');
+
+    // Auto-load current group (first/only group in groups_data)
+    function loadGroup() {
+        if (groups.length > 0) {
+            const group = groups[0];
+            const members = group.members;
+            
+            // Update payer dropdown
+            payerSelect.innerHTML = '<option value="">Select payer...</option>';
+            members.forEach(member => {
+                const option = document.createElement('option');
+                option.value = member.email;
+                option.textContent = member.display_name;
+                payerSelect.appendChild(option);
+            });
+            
+            // Update participants list for equal split
+            participantsList.innerHTML = '';
+            members.forEach(member => {
+                const div = document.createElement('div');
+                div.className = 'flex items-center';
+                div.innerHTML = `
+                    <input type="checkbox" name="participants" value="${member.email}" id="participant_${member.email}" class="mr-2" checked>
+                    <label for="participant_${member.email}" class="text-sm">${member.display_name}</label>
+                `;
+                participantsList.appendChild(div);
+            });
+            
+            // Update custom amounts list
+            customAmountsList.innerHTML = '';
+            members.forEach(member => {
+                const div = document.createElement('div');
+                div.className = 'flex items-center gap-2';
+                div.innerHTML = `
+                    <label class="text-sm w-20">${member.display_name}:</label>
+                    <input type="number" name="custom_amount_${member.email}" step="0.01" min="0" 
+                           class="flex-1 px-2 py-1 bg-slate-950/50 border border-cyan-500/30 rounded text-sm custom-amount-input">
+                `;
+                customAmountsList.appendChild(div);
+            });
+            
+            updateSplitCalculations();
+        }
+    }
+    
+    // Load group on page load
+    loadGroup();
+
+    // Handle split type change
+    splitTypeRadios.forEach(radio => {
+        radio.addEventListener('change', function() {
+            if (this.value === 'equal') {
+                equalSplitOptions.classList.add('active');
+                customSplitOptions.classList.remove('active');
+            } else {
+                equalSplitOptions.classList.remove('active');
+                customSplitOptions.classList.add('active');
+            }
+            updateSplitCalculations();
+        });
+    });
+
+    // Handle amount change
+    amountInput.addEventListener('input', updateSplitCalculations);
+
+    // Handle participant selection change
+    participantsList.addEventListener('change', updateSplitCalculations);
+
+    // Handle custom amount changes
+    customAmountsList.addEventListener('input', function(e) {
+        if (e.target.classList.contains('custom-amount-input')) {
+            updateSplitCalculations();
+        }
+    });
+
+    function updateSplitCalculations() {
+        const amount = parseFloat(amountInput.value) || 0;
+        const selectedSplitType = document.querySelector('input[name="split_type"]:checked').value;
+        
+        if (selectedSplitType === 'equal') {
+            const selectedParticipants = Array.from(participantsList.querySelectorAll('input[type="checkbox"]:checked'));
+            const participantCount = selectedParticipants.length;
+            
+            if (participantCount > 0 && amount > 0) {
+                const share = amount / participantCount;
+                splitAmount.textContent = '$' + share.toFixed(2);
+                equalSplitSummary.style.display = 'block';
+            } else {
+                equalSplitSummary.style.display = 'none';
+            }
+        } else {
+            const customInputs = customAmountsList.querySelectorAll('.custom-amount-input');
+            let total = 0;
+            customInputs.forEach(input => {
+                total += parseFloat(input.value) || 0;
+            });
+            
+            customTotal.textContent = total.toFixed(2);
+            customExpected.textContent = amount.toFixed(2);
+            
+            if (amount > 0) {
+                customSplitSummary.style.display = 'block';
+                if (Math.abs(total - amount) < 0.01) {
+                    customSplitSummary.className = 'mt-2 text-sm text-green-300';
+                } else {
+                    customSplitSummary.className = 'mt-2 text-sm text-red-300';
+                }
+            } else {
+                customSplitSummary.style.display = 'none';
+            }
+        }
+    }
+
+    // Form validation
+    document.getElementById('expenseForm').addEventListener('submit', function(e) {
+        const amount = parseFloat(amountInput.value);
+        const selectedSplitType = document.querySelector('input[name="split_type"]:checked').value;
+        
+        // Validate amount
+        if (amount <= 0) {
+            e.preventDefault();
+            alert('Amount must be greater than zero');
+            return;
+        }
+        
+        // Validate participants
+        if (selectedSplitType === 'equal') {
+            const selectedParticipants = participantsList.querySelectorAll('input[type="checkbox"]:checked');
+            if (selectedParticipants.length === 0) {
+                e.preventDefault();
+                alert('Please select at least one participant');
+                return;
+            }
+        } else {
+            const customInputs = customAmountsList.querySelectorAll('.custom-amount-input');
+            let total = 0;
+            let hasAnyAmount = false;
+            
+            customInputs.forEach(input => {
+                const value = parseFloat(input.value) || 0;
+                total += value;
+                if (value > 0) hasAnyAmount = true;
+            });
+            
+            if (!hasAnyAmount) {
+                e.preventDefault();
+                alert('Please specify amounts for at least one participant');
+                return;
+            }
+            
+            if (Math.abs(total - amount) > 0.01) {
+                e.preventDefault();
+                alert(`Custom split total ($${total.toFixed(2)}) must equal expense amount ($${amount.toFixed(2)})`);
+                return;
+            }
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/templates/groups/index.html
+++ b/templates/groups/index.html
@@ -72,43 +72,16 @@
     </div>
 </div>
 
-<div class="grid lg:grid-cols-2 gap-8">
-    <div class="bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl shadow-xl border border-cyan-500/20 p-6 text-white">
-        <div class="flex items-center justify-between mb-6">
-            <div class="flex items-center gap-2">
-                <span class="text-xl">⚡</span>
-                <h3 class="text-lg font-semibold">New Group</h3>
-            </div>
-            <span class="text-xs font-mono text-cyan-400 bg-cyan-400/10 px-3 py-1 rounded-full border border-cyan-400/20">
-                TERMINAL.GROUP.ADD
-            </span>
-        </div>
+<div class="mb-6 flex items-center justify-between">
+    <div></div>
+    <a href="{{ url_for('groups.create_group') }}"
+        class="inline-flex items-center gap-2 bg-gradient-to-r from-cyan-500 to-teal-500 text-white px-6 py-3 rounded-lg font-bold hover:from-cyan-400 hover:to-teal-400 transform hover:scale-[1.02] transition-all duration-200 shadow-lg uppercase tracking-wider">
+        <span class="text-xl">+</span>
+        CREATE NEW GROUP
+    </a>
+</div>
 
-        <form method="POST" action="{{ url_for('groups.create_group') }}" class="space-y-4">
-            <div>
-                <label for="name" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Group Name</label>
-                <input type="text" id="name" name="name"
-                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
-                    placeholder="Team Alpha, Project X..." required>
-            </div>
-
-            <div>
-                <label for="members" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Additional Member Emails (Optional)</label>
-                <textarea id="members" name="members"
-                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
-                    placeholder="alice@example.com, bob@example.com" rows="4"></textarea>
-                <span class="text-xs text-gray-400 mt-1">Comma-separated email addresses. You (the creator) will be added automatically.</span>
-            </div>
-
-            <button type="submit"
-                class="w-full bg-gradient-to-r from-cyan-500 to-teal-500 text-slate-900 py-3 rounded-lg font-bold hover:from-cyan-400 hover:to-teal-400 transform hover:scale-[1.02] transition-all duration-200 shadow-lg uppercase tracking-wider flex items-center justify-center gap-2">
-                <span class="text-xl">+</span>
-                CREATE GROUP
-            </button>
-        </form>
-    </div>
-
-    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+<div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
         <div class="flex items-center justify-between mb-6">
             <div class="flex items-center gap-2">
                 <span class="text-xl">📊</span>
@@ -122,32 +95,38 @@
         {% if groups %}
             <div class="space-y-3 max-h-96 overflow-y-auto">
                 {% for group in groups %}
-                <div class="group relative bg-gradient-to-r from-slate-50 to-gray-50 rounded-xl border border-gray-200 p-4 hover:shadow-md transition-all duration-200">
-                    <span class="absolute -top-2 right-4 text-xs font-mono font-bold bg-gradient-to-r from-cyan-500 to-teal-500 text-white px-2 py-1 rounded">
-                        #{{ loop.index }}
-                    </span>
+                <a href="{{ url_for('groups.group_expenses', group_id=group.id) }}" class="block">
+                    <div class="group relative bg-gradient-to-r from-slate-50 to-gray-50 rounded-xl border border-gray-200 p-4 hover:shadow-md hover:border-cyan-300 transition-all duration-200 cursor-pointer">
+                        <span class="absolute -top-2 right-4 text-xs font-mono font-bold bg-gradient-to-r from-cyan-500 to-teal-500 text-white px-2 py-1 rounded">
+                            #{{ loop.index }}
+                        </span>
 
-                    <div class="flex items-start justify-between mb-3">
-                        <div>
-                            <h4 class="font-semibold text-gray-900">{{ group.name }}</h4>
-                        </div>
-                    </div>
-
-                    <div class="border-t border-gray-200 pt-3">
-                        <div class="flex items-center justify-between">
-                            <div class="flex flex-wrap gap-1">
-                                {% for member in group.members %}
-                                    <span class="text-xs font-mono bg-cyan-100 text-cyan-700 px-2 py-0.5 rounded">
-                                        {{ member.display_name or member.email }}
-                                    </span>
-                                {% endfor %}
+                        <div class="flex items-start justify-between mb-3">
+                            <div class="flex-1">
+                                <h4 class="font-semibold text-gray-900 group-hover:text-cyan-600 transition-colors">{{ group.name }}</h4>
+                                <p class="text-xs text-gray-500 mt-1">Click to view expenses</p>
                             </div>
-                            <span class="text-xs text-gray-400 font-mono">
-                                {{ group.created_at.strftime('%Y-%m-%d %H:%M') }}
-                            </span>
+                            <svg class="w-5 h-5 text-gray-400 group-hover:text-cyan-600 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                            </svg>
+                        </div>
+
+                        <div class="border-t border-gray-200 pt-3">
+                            <div class="flex items-center justify-between">
+                                <div class="flex flex-wrap gap-1">
+                                    {% for member in group.members %}
+                                        <span class="text-xs font-mono bg-cyan-100 text-cyan-700 px-2 py-0.5 rounded">
+                                            {{ member.display_name or member.email }}
+                                        </span>
+                                    {% endfor %}
+                                </div>
+                                <span class="text-xs text-gray-400 font-mono">
+                                    {{ group.created_at.strftime('%Y-%m-%d %H:%M') }}
+                                </span>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </a>
                 {% endfor %}
             </div>
         {% else %}
@@ -157,7 +136,7 @@
                     <span class="text-2xl font-mono text-emerald-600 pulse-animation">_</span>
                 </div>
                 <p class="text-gray-500 font-mono mb-2">AWAITING FIRST GROUP...</p>
-                <p class="text-sm text-gray-400">Initialize your groups by creating one above.</p>
+                <p class="text-sm text-gray-400">Initialize your groups by creating one using the button above.</p>
             </div>
         {% endif %}
     </div>

--- a/tests/test_expense_notifications.py
+++ b/tests/test_expense_notifications.py
@@ -24,13 +24,10 @@ def test_expense_creation_sends_notification_to_participants(client, app):
     from models import Group
 
     with app.app_context():
-        payer = User(email="payer@example.com")
-        participant1 = User(email="participant1@example.com")
-        participant2 = User(email="participant2@example.com")
         john = User(email="john@example.com")
         alice = User(email="alice@example.com")
         bob_user = User(email="bob@example.com")
-        db.session.add_all([payer, participant1, participant2, john, alice, bob_user])
+        db.session.add_all([john, alice, bob_user])
         db.session.flush()
 
         # Create a group with members
@@ -39,25 +36,31 @@ def test_expense_creation_sends_notification_to_participants(client, app):
         db.session.add(group)
         db.session.commit()
 
-        payer_id = payer.id
+        payer_id = john.id  # Use john who is in the group
         group_id = group.id
 
     with client.session_transaction() as sess:
         sess["user_id"] = payer_id
-        sess["user_email"] = "payer@example.com"
+        sess["user_email"] = "john@example.com"
 
     # Act
-    with patch("services.notification_service.print") as mock_print:
+    from werkzeug.datastructures import MultiDict
+
+    with patch("builtins.print") as mock_print:
+        expense_data = MultiDict(
+            [
+                ("description", "Dinner at restaurant"),
+                ("amount", "150.00"),
+                ("payer", "john@example.com"),
+                ("split_type", "equal"),
+                ("participants", "john@example.com"),
+                ("participants", "alice@example.com"),
+                ("participants", "bob@example.com"),
+            ]
+        )
         response = client.post(
-            "/expense-splitter",
-            data={
-                "description": "Dinner at restaurant",
-                "amount": "150.00",
-                "payer": "john@example.com",
-                "group_id": str(group_id),
-                "split_type": "equal",
-                "participants": ["john@example.com", "alice@example.com", "bob@example.com"],
-            },
+            f"/groups/{group_id}",
+            data=expense_data,
             follow_redirects=False,
         )
 
@@ -123,11 +126,9 @@ def test_expense_notification_contains_all_details(client, app):
     from models import Group
 
     with app.app_context():
-        payer = User(email="payer@example.com")
-        participant = User(email="participant@example.com")
         bob_user = User(email="bob@example.com")
         charlie = User(email="charlie@example.com")
-        db.session.add_all([payer, participant, bob_user, charlie])
+        db.session.add_all([bob_user, charlie])
         db.session.flush()
 
         # Create a group with members
@@ -136,25 +137,27 @@ def test_expense_notification_contains_all_details(client, app):
         db.session.add(group)
         db.session.commit()
 
-        payer_id = payer.id
+        payer_id = bob_user.id  # Use bob who is in the group
         group_id = group.id
 
     with client.session_transaction() as sess:
         sess["user_id"] = payer_id
 
     # Act
-    with patch("services.notification_service.print") as mock_print:
-        client.post(
-            "/expense-splitter",
-            data={
-                "description": "Movie tickets",
-                "amount": "30.00",
-                "payer": "bob@example.com",
-                "group_id": str(group_id),
-                "split_type": "equal",
-                "participants": ["bob@example.com", "charlie@example.com"],
-            },
+    from werkzeug.datastructures import MultiDict
+
+    with patch("builtins.print") as mock_print:
+        expense_data = MultiDict(
+            [
+                ("description", "Movie tickets"),
+                ("amount", "30.00"),
+                ("payer", "bob@example.com"),
+                ("split_type", "equal"),
+                ("participants", "bob@example.com"),
+                ("participants", "charlie@example.com"),
+            ]
         )
+        client.post(f"/groups/{group_id}", data=expense_data)
 
         # Assert
         assert mock_print.called
@@ -172,11 +175,9 @@ def test_multiple_expenses_send_separate_notifications(client, app):
     from models import Group
 
     with app.app_context():
-        payer = User(email="payer@example.com")
-        participant = User(email="participant@example.com")
         charlie = User(email="charlie@example.com")
         dave = User(email="dave@example.com")
-        db.session.add_all([payer, participant, charlie, dave])
+        db.session.add_all([charlie, dave])
         db.session.flush()
 
         # Create a group with members
@@ -185,39 +186,41 @@ def test_multiple_expenses_send_separate_notifications(client, app):
         db.session.add(group)
         db.session.commit()
 
-        payer_id = payer.id
+        payer_id = charlie.id  # Use charlie who is in the group
         group_id = group.id
 
     with client.session_transaction() as sess:
         sess["user_id"] = payer_id
 
     # Act
-    with patch("services.notification_service.print") as mock_print:
+    from werkzeug.datastructures import MultiDict
+
+    with patch("builtins.print") as mock_print:
         # Create first expense
-        client.post(
-            "/expense-splitter",
-            data={
-                "description": "Lunch",
-                "amount": "25.00",
-                "payer": "charlie@example.com",
-                "group_id": str(group_id),
-                "split_type": "equal",
-                "participants": ["charlie@example.com", "dave@example.com"],
-            },
+        expense1_data = MultiDict(
+            [
+                ("description", "Lunch"),
+                ("amount", "25.00"),
+                ("payer", "charlie@example.com"),
+                ("split_type", "equal"),
+                ("participants", "charlie@example.com"),
+                ("participants", "dave@example.com"),
+            ]
         )
+        client.post(f"/groups/{group_id}", data=expense1_data)
 
         # Create second expense
-        client.post(
-            "/expense-splitter",
-            data={
-                "description": "Coffee",
-                "amount": "10.00",
-                "payer": "charlie@example.com",
-                "group_id": str(group_id),
-                "split_type": "equal",
-                "participants": ["charlie@example.com", "dave@example.com"],
-            },
+        expense2_data = MultiDict(
+            [
+                ("description", "Coffee"),
+                ("amount", "10.00"),
+                ("payer", "charlie@example.com"),
+                ("split_type", "equal"),
+                ("participants", "charlie@example.com"),
+                ("participants", "dave@example.com"),
+            ]
         )
+        client.post(f"/groups/{group_id}", data=expense2_data)
 
         # Assert
         assert mock_print.called
@@ -234,11 +237,9 @@ def test_expense_notification_is_sent(client, app):
     from models import Group
 
     with app.app_context():
-        payer = User(email="payer@example.com")
-        participant = User(email="participant@example.com")
         diana = User(email="diana@example.com")
         eve = User(email="eve@example.com")
-        db.session.add_all([payer, participant, diana, eve])
+        db.session.add_all([diana, eve])
         db.session.flush()
 
         # Create a group with members
@@ -247,25 +248,27 @@ def test_expense_notification_is_sent(client, app):
         db.session.add(group)
         db.session.commit()
 
-        payer_id = payer.id
+        payer_id = diana.id  # Use diana who is in the group
         group_id = group.id
 
     with client.session_transaction() as sess:
         sess["user_id"] = payer_id
 
     # Act
-    with patch("services.notification_service.print") as mock_print:
-        client.post(
-            "/expense-splitter",
-            data={
-                "description": "Test expense",
-                "amount": "100.00",
-                "payer": "diana@example.com",
-                "group_id": str(group_id),
-                "split_type": "equal",
-                "participants": ["diana@example.com", "eve@example.com"],
-            },
+    from werkzeug.datastructures import MultiDict
+
+    with patch("builtins.print") as mock_print:
+        expense_data = MultiDict(
+            [
+                ("description", "Test expense"),
+                ("amount", "100.00"),
+                ("payer", "diana@example.com"),
+                ("split_type", "equal"),
+                ("participants", "diana@example.com"),
+                ("participants", "eve@example.com"),
+            ]
         )
+        client.post(f"/groups/{group_id}", data=expense_data)
 
         # Assert
         assert mock_print.called
@@ -299,23 +302,21 @@ def test_payer_does_not_receive_notification(client, app):
         sess["user_email"] = "payer@example.com"
 
     # Act
-    with patch("routes.expenses.notify_expense_participants") as mock_notify:
-        response = client.post(
-            "/expense-splitter",
-            data={
-                "description": "Team lunch",
-                "amount": "90.00",
-                "payer": "payer@example.com",
-                "group_id": str(group_id),
-                "split_type": "equal",
-                "participants": [
-                    "payer@example.com",
-                    "participant1@example.com",
-                    "participant2@example.com",
-                ],
-            },
-            follow_redirects=False,
+    from werkzeug.datastructures import MultiDict
+
+    with patch("routes.groups.notify_expense_participants") as mock_notify:
+        expense_data = MultiDict(
+            [
+                ("description", "Team lunch"),
+                ("amount", "90.00"),
+                ("payer", "payer@example.com"),
+                ("split_type", "equal"),
+                ("participants", "payer@example.com"),
+                ("participants", "participant1@example.com"),
+                ("participants", "participant2@example.com"),
+            ]
         )
+        response = client.post(f"/groups/{group_id}", data=expense_data, follow_redirects=False)
 
         # Assert
         assert response.status_code == 302  # Redirect after success

--- a/tests/test_expense_routes.py
+++ b/tests/test_expense_routes.py
@@ -3,8 +3,8 @@
 from models import Expense, Group, User
 
 
-def test_expense_splitter_get_returns_ok(client, app):
-    """Test that GET /expense-splitter returns a 200 status code."""
+def test_expense_splitter_get_redirects_to_groups(client, app):
+    """Test that GET /expense-splitter redirects to groups list."""
     # Arrange
     from extensions import db
 
@@ -20,10 +20,41 @@ def test_expense_splitter_get_returns_ok(client, app):
         session["user_email"] = "test@example.com"
 
     # Act
-    response = client.get("/expense-splitter")
+    response = client.get("/expense-splitter", follow_redirects=False)
 
-    # Assert
-    assert response.status_code == 200
+    # Assert - should redirect to groups list
+    assert response.status_code == 302
+    assert "/groups/" in response.location
+
+
+def test_expense_splitter_post_redirects_to_groups(client, app):
+    """Test that POST /expense-splitter redirects to groups list."""
+    # Arrange
+    from extensions import db
+
+    # Create users and group
+    alex = User(email="alex@example.com")
+    sam = User(email="sam@example.com")
+    jo = User(email="jo@example.com")
+    db.session.add_all([alex, sam, jo])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=alex.id)
+    group.members.extend([alex, sam, jo])
+    db.session.add(group)
+    db.session.commit()
+
+    # Create a logged-in user session
+    with client.session_transaction() as session:
+        session["user_id"] = 1
+        session["user_email"] = "test@example.com"
+
+    # Act - try to POST to expense-splitter (should redirect)
+    response = client.post("/expense-splitter", follow_redirects=False)
+
+    # Assert - should redirect to groups list
+    assert response.status_code == 302
+    assert "/groups/" in response.location
 
 
 def test_expense_splitter_post_creates_expense(client, app):
@@ -48,21 +79,27 @@ def test_expense_splitter_post_creates_expense(client, app):
         session["user_id"] = 1
         session["user_email"] = "test@example.com"
 
-    expense_data = {
-        "description": "Dinner",
-        "amount": "36.75",
-        "payer": "alex@example.com",
-        "group_id": str(group.id),
-        "split_type": "equal",
-        "participants": ["alex@example.com", "sam@example.com", "jo@example.com"],
-    }
+    # Use MultiDict to handle multiple participants
+    from werkzeug.datastructures import MultiDict
 
-    # Act
-    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "36.75"),
+            ("payer", "alex@example.com"),
+            ("split_type", "equal"),
+            ("participants", "alex@example.com"),
+            ("participants", "sam@example.com"),
+            ("participants", "jo@example.com"),
+        ]
+    )
+
+    # Act - use new group-specific route
+    response = client.post(f"/groups/{group.id}", data=expense_data, follow_redirects=False)
 
     # Assert
     assert response.status_code == 302
-    stored = Expense.query.filter_by(description="Dinner").first()
+    stored = Expense.query.filter_by(description="Dinner", group_id=group.id).first()
     assert stored is not None
     assert stored.amount == 36.75
     assert stored.payer == "alex@example.com"
@@ -164,9 +201,9 @@ def test_groups_create_group_rejects_invalid_member_emails(client, app):
     # Act
     response = client.post("/groups/create", data=group_data, follow_redirects=False)
 
-    # Assert - should redirect back to groups page
+    # Assert - should redirect back to create page
     assert response.status_code == 302
-    assert response.location == "/groups/"
+    assert response.location.endswith("/groups/create")
     # Group should not have been created
     assert Group.query.filter_by(name="Invalid Email Group").first() is None
 
@@ -462,24 +499,29 @@ def test_expense_splitter_creates_equal_split_expense(client, app):
     db.session.commit()
 
     with client.session_transaction() as session:
-        session["user_id"] = 1
-        session["user_email"] = "test@example.com"
+        session["user_id"] = alice.id
+        session["user_email"] = "alice@example.com"
 
-    expense_data = {
-        "description": "Dinner",
-        "amount": "60.00",
-        "payer": "alice@example.com",
-        "group_id": str(group.id),
-        "split_type": "equal",
-        "participants": ["alice@example.com", "bob@example.com", "charlie@example.com"],
-    }
+    from werkzeug.datastructures import MultiDict
 
-    # Act
-    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "60.00"),
+            ("payer", "alice@example.com"),
+            ("split_type", "equal"),
+            ("participants", "alice@example.com"),
+            ("participants", "bob@example.com"),
+            ("participants", "charlie@example.com"),
+        ]
+    )
+
+    # Act - use new group-specific route
+    response = client.post(f"/groups/{group.id}", data=expense_data, follow_redirects=False)
 
     # Assert
     assert response.status_code == 302  # Redirect after success
-    stored = Expense.query.first()
+    stored = Expense.query.filter_by(description="Dinner", group_id=group.id).first()
     assert stored is not None
     assert stored.description == "Dinner"
     assert stored.amount == 60.0
@@ -518,26 +560,25 @@ def test_expense_splitter_creates_custom_split_expense(client, app):
     db.session.commit()
 
     with client.session_transaction() as session:
-        session["user_id"] = 1
-        session["user_email"] = "test@example.com"
+        session["user_id"] = alice.id
+        session["user_email"] = "alice@example.com"
 
     expense_data = {
         "description": "Dinner",
         "amount": "60.00",
         "payer": "alice@example.com",
-        "group_id": str(group.id),
         "split_type": "custom",
         "custom_amount_alice@example.com": "30.00",
         "custom_amount_bob@example.com": "20.00",
         "custom_amount_charlie@example.com": "10.00",
     }
 
-    # Act
-    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+    # Act - use new group-specific route
+    response = client.post(f"/groups/{group.id}", data=expense_data, follow_redirects=False)
 
     # Assert
     assert response.status_code == 302  # Redirect after success
-    stored = Expense.query.first()
+    stored = Expense.query.filter_by(description="Dinner", group_id=group.id).first()
     assert stored is not None
     assert stored.split_type == "custom"
 
@@ -570,25 +611,24 @@ def test_expense_splitter_rejects_custom_split_mismatch(client, app):
     db.session.commit()
 
     with client.session_transaction() as session:
-        session["user_id"] = 1
-        session["user_email"] = "test@example.com"
+        session["user_id"] = alice.id
+        session["user_email"] = "alice@example.com"
 
     expense_data = {
         "description": "Dinner",
         "amount": "50.00",
         "payer": "alice@example.com",
-        "group_id": str(group.id),
         "split_type": "custom",
         "custom_amount_alice@example.com": "30.00",
         "custom_amount_bob@example.com": "20.00",  # Total = 50, should be valid
     }
 
-    # Act
-    response = client.post("/expense-splitter", data=expense_data, follow_redirects=False)
+    # Act - use new group-specific route
+    response = client.post(f"/groups/{group.id}", data=expense_data, follow_redirects=False)
 
     # Assert
     assert response.status_code == 302  # Should succeed
-    assert Expense.query.count() == 1
+    assert Expense.query.filter_by(group_id=group.id).count() == 1
 
 
 def test_expense_splitter_rejects_custom_split_total_mismatch(client, app):
@@ -684,11 +724,11 @@ def test_expense_splitter_filters_by_group(client, app):
     db.session.commit()
 
     with client.session_transaction() as session:
-        session["user_id"] = 1
-        session["user_email"] = "test@example.com"
+        session["user_id"] = alice.id
+        session["user_email"] = "alice@example.com"
 
-    # Act
-    response = client.get(f"/expense-splitter?group_id={group1.id}")
+    # Act - use new group-specific route
+    response = client.get(f"/groups/{group1.id}")
 
     # Assert
     assert response.status_code == 200
@@ -1178,8 +1218,8 @@ def test_expense_splitter_displays_user_display_names(client, app):
         session["user_id"] = alice.id
         session["user_email"] = "alice@example.com"
 
-    # Get the expense splitter page
-    response = client.get("/expense-splitter")
+    # Get the group expenses page
+    response = client.get(f"/groups/{group.id}")
     assert response.status_code == 200
 
     # Check that display names are shown instead of emails

--- a/tests/test_group_routes.py
+++ b/tests/test_group_routes.py
@@ -81,7 +81,7 @@ def test_groups_create_group_rejects_invalid_member_emails(client, app):
     # Act
     response = client.post("/groups/create", data=group_data, follow_redirects=True)
 
-    # Assert - should redirect back to groups page with error message
+    # Assert - should redirect back to create page with error message
     assert response.status_code == 200
     assert b"Invalid email format: notanemail" in response.data
     # Group should not have been created
@@ -138,8 +138,9 @@ def test_groups_create_group_requires_name(client, app):
     # Act
     response = client.post("/groups/create", data=group_data, follow_redirects=False)
 
-    # Assert - should redirect back with error
+    # Assert - should redirect back to create page with error
     assert response.status_code == 302
+    assert response.location.endswith("/groups/create")
     assert Group.query.count() == 0  # No group created
 
 
@@ -210,6 +211,153 @@ def test_groups_create_handles_database_error(client, app, monkeypatch):
     # Act
     response = client.post("/groups/create", data=group_data, follow_redirects=True)
 
-    # Assert - should redirect with error message
+    # Assert - should redirect to create page with error message
     assert response.status_code == 200
     assert b"Failed to create group" in response.data
+
+
+def test_groups_create_get_returns_ok(client, app):
+    """Test that GET /groups/create returns 200 for logged-in user."""
+    # Arrange
+    from extensions import db
+
+    user = User(email="test@example.com")
+    db.session.add(user)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["user_email"] = user.email
+
+    # Act
+    response = client.get("/groups/create")
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Create Group" in response.data or b"CREATE GROUP" in response.data
+
+
+def test_groups_create_get_requires_login(client):
+    """Test that GET /groups/create requires login."""
+    # Act - no login session
+    response = client.get("/groups/create", follow_redirects=False)
+
+    # Assert - should redirect to login
+    assert response.status_code == 302
+
+
+def test_group_expenses_get_returns_ok(client, app):
+    """Test that GET /groups/<group_id> returns 200 for logged-in group member."""
+    # Arrange
+    from extensions import db
+
+    user = User(email="test@example.com")
+    db.session.add(user)
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=user.id)
+    group.members.append(user)
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["user_email"] = user.email
+
+    # Act
+    response = client.get(f"/groups/{group.id}")
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Test Group" in response.data
+
+
+def test_group_expenses_get_requires_login(client, app):
+    """Test that GET /groups/<group_id> requires login."""
+    # Arrange
+    from extensions import db
+
+    user = User(email="test@example.com")
+    db.session.add(user)
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=user.id)
+    group.members.append(user)
+    db.session.add(group)
+    db.session.commit()
+
+    # Act - no login session
+    response = client.get(f"/groups/{group.id}", follow_redirects=False)
+
+    # Assert - should redirect to login
+    assert response.status_code == 302
+
+
+def test_group_expenses_requires_membership(client, app):
+    """Test that GET /groups/<group_id> requires user to be a group member."""
+    # Arrange
+    from extensions import db
+
+    member = User(email="member@example.com")
+    non_member = User(email="nonmember@example.com")
+    db.session.add_all([member, non_member])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=member.id)
+    group.members.append(member)
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = non_member.id
+        sess["user_email"] = non_member.email
+
+    # Act
+    response = client.get(f"/groups/{group.id}", follow_redirects=False)
+
+    # Assert - should redirect or return 403
+    assert response.status_code in [302, 403]
+
+
+def test_group_expenses_post_creates_expense(client, app):
+    """Test that POST /groups/<group_id> creates expense for that group."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    participant = User(email="participant@example.com")
+    db.session.add_all([payer, participant])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, participant])
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    # Create MultiDict to handle multiple participants
+    expense_data = MultiDict(
+        [
+            ("description", "Lunch"),
+            ("amount", "30.00"),
+            ("payer", "payer@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "participant@example.com"),
+        ]
+    )
+
+    # Act
+    response = client.post(f"/groups/{group.id}", data=expense_data, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302  # Redirect after creation
+    expense = Expense.query.filter_by(description="Lunch", group_id=group.id).first()
+    assert expense is not None
+    assert expense.amount == 30.0

--- a/tests/test_protected_routes.py
+++ b/tests/test_protected_routes.py
@@ -14,7 +14,7 @@ def test_expense_splitter_redirects_if_not_logged_in(client):
 
 
 def test_expense_splitter_accessible_when_logged_in(client, app):
-    """Test that /expense-splitter is accessible when user is logged in."""
+    """Test that /expense-splitter redirects to groups when user is logged in."""
     # Arrange - create user and simulate logged in session
     from extensions import db
 
@@ -29,10 +29,11 @@ def test_expense_splitter_accessible_when_logged_in(client, app):
         sess["user_email"] = "test@example.com"
 
     # Act
-    response = client.get("/expense-splitter")
+    response = client.get("/expense-splitter", follow_redirects=False)
 
-    # Assert
-    assert response.status_code == 200
+    # Assert - should redirect to groups list
+    assert response.status_code == 302
+    assert "/groups/" in response.location
 
 
 def test_expense_splitter_clears_stale_session(client, app):


### PR DESCRIPTION
📋 Description

Split the group management into two pages. One to list the groups and one to create a new group.
🎯 Changes Made

    The list groups page will only list the groups and the members under those groups.
    Created a new page for creating a new group.

🧪 Testing

    All tests pass (uv run pytest -v)
    Coverage meets requirements (most are 95%+ per file, 80% overall)
    Updated existing tests to match new behavior

🔗 Related Story

Closes #30 

📸 Screenshots
Create group:
<img width="873" height="616" alt="Screenshot 2025-11-02 at 12 52 54 PM" src="https://github.com/user-attachments/assets/256adb13-031e-4ebb-99ec-8efa17401eab" />

List groups:
<img width="887" height="650" alt="Screenshot 2025-11-02 at 12 52 41 PM" src="https://github.com/user-attachments/assets/689362d2-ece7-4075-9a4b-9f9d048a6212" />


🔄 Files Changed

    routes/expenses.py
    routes/groups.py
    templates/groups/create.html
    templates/groups/expenses.html
    templates/groups/index.html
    test_expense_notifications.py - updated
    test_expense_routes.py - updated
    test_group_routes.py - updated
    test_protected_routes.py - updated


