### PR TITLE
feat: add edit expense feature with inline form

### DIFF
--- a/models.py
+++ b/models.py
@@ -121,15 +121,16 @@ class GroupInvitation(db.Model):
 
 
 class GroupNotification(db.Model):
-    """Model for tracking group notifications like expense deletions."""
+    """Model for tracking group notifications like expense deletions and edits."""
 
     id = db.Column(db.Integer, primary_key=True)
     group_id = db.Column(db.Integer, db.ForeignKey("group.id"), nullable=False)
-    notification_type = db.Column(db.String(50), nullable=False)  # 'expense_deleted'
+    notification_type = db.Column(db.String(50), nullable=False)  # 'expense_deleted', 'expense_edited'
     description = db.Column(db.String(200), nullable=False)
     amount = db.Column(db.Float, nullable=True)
     payer = db.Column(db.String(200), nullable=True)
     deleted_by = db.Column(db.String(200), nullable=True)
+    edited_by = db.Column(db.String(200), nullable=True)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     read_by = db.Column(db.Text)  # JSON array of user IDs who have seen this
 

--- a/routes/groups.py
+++ b/routes/groups.py
@@ -7,6 +7,7 @@ from models import Expense, Group, GroupInvitation, User
 from services.expense_service import ExpenseService
 from services.notification_service import (
     notify_expense_deletion,
+    notify_expense_edited,
     notify_expense_participants,
     notify_group_invitation,
 )
@@ -298,17 +299,18 @@ def group_expenses(group_id):
         }
     ]
 
-    # Check for expense deletion notification
+    # Check for expense deletion and edit notifications
     deletion_info = None
+    edit_info = None
     from models import GroupNotification
 
-    # Get unread notifications for this group
-    notifications = GroupNotification.query.filter_by(
+    # Get unread deletion notifications for this group
+    deletion_notifications = GroupNotification.query.filter_by(
         group_id=group_id, notification_type="expense_deleted"
     ).order_by(GroupNotification.created_at.desc()).all()
 
-    # Find notifications the current user hasn't seen
-    for notification in notifications:
+    # Find deletion notifications the current user hasn't seen
+    for notification in deletion_notifications:
         read_by_ids = json.loads(notification.read_by) if notification.read_by else []
         if user.id not in read_by_ids:
             deletion_info = {
@@ -320,6 +322,27 @@ def group_expenses(group_id):
             }
             break  # Show the most recent unread notification
 
+    # Get unread edit notifications for this group
+    edit_notifications = GroupNotification.query.filter_by(
+        group_id=group_id, notification_type="expense_edited"
+    ).order_by(GroupNotification.created_at.desc()).all()
+
+    # Find edit notifications the current user hasn't seen
+    for notification in edit_notifications:
+        read_by_ids = json.loads(notification.read_by) if notification.read_by else []
+        if user.id not in read_by_ids:
+            edit_info = {
+                "description": notification.description,
+                "amount": str(notification.amount) if notification.amount else "",
+                "payer": notification.payer or "",
+                "edited_by": notification.edited_by or "",
+                "notification_id": notification.id,
+            }
+            break  # Show the most recent unread notification
+
+    # Count total transactions
+    transaction_count = len(expenses)
+
     return render_template(
         "groups/expenses.html",
         group=group,
@@ -327,6 +350,8 @@ def group_expenses(group_id):
         groups_data=groups_data,
         email_to_name=email_to_name,
         deletion_info=deletion_info,
+        edit_info=edit_info,
+        transaction_count=transaction_count,
     )
 
 
@@ -404,6 +429,160 @@ def delete_expense(group_id, expense_id):
     db.session.commit()
 
     flash("Expense deleted successfully!", "success")
+    return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+
+@groups_bp.route("/<int:group_id>/expense/<int:expense_id>/edit", methods=["POST"])
+@login_required
+def edit_expense(group_id, expense_id):
+    """Edit an expense in a group."""
+    user_id = session.get("user_id")
+    user = db.session.get(User, user_id)
+
+    if not user:
+        flash("User not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    # Get the group and verify user is a member
+    group = db.session.get(Group, group_id)
+    if not group:
+        flash("Group not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    if user not in group.members:
+        flash("You are not a member of this group", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    # Get the expense and verify it belongs to the group
+    expense = db.session.get(Expense, expense_id)
+    if not expense:
+        flash("Expense not found", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    if expense.group_id != group_id:
+        flash("Expense does not belong to this group", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Extract form data
+    description = request.form.get("description", "").strip()
+    amount_raw = request.form.get("amount", "").strip()
+    payer = request.form.get("payer", "").strip()
+    split_type = request.form.get("split_type", "equal").strip()
+
+    # Validate required fields
+    if not description:
+        flash("Description is required", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    if not payer:
+        flash("Payer is required", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Validate amount (must be > 0)
+    try:
+        amount = float(amount_raw)
+        if amount <= 0:
+            flash("Amount must be greater than zero", "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+    except (ValueError, TypeError):
+        flash("Please enter a valid amount", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Get group member emails for validation
+    group_member_emails = [member.email for member in group.members]
+
+    # Validate payer is in group
+    if payer not in group_member_emails:
+        flash("Payer must be a member of the group", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Handle participants and split details
+    if split_type == "equal":
+        # Get selected participants for equal split
+        selected_participants = request.form.getlist("participants")
+        if not selected_participants:
+            flash("Please select at least one participant", "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        # Validate all participants are in group
+        for participant in selected_participants:
+            if participant not in group_member_emails:
+                flash(f"Participant '{participant}' is not in the group", "error")
+                return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        # Calculate equal split
+        split_details = ExpenseService.calculate_equal_split(selected_participants, amount)
+
+    else:  # custom split
+        # Get custom split amounts
+        split_details = {}
+        for member_email in group_member_emails:
+            amount_key = f"custom_amount_{member_email}"
+            custom_amount = request.form.get(amount_key, "").strip()
+            if custom_amount:
+                try:
+                    split_details[member_email] = float(custom_amount)
+                except ValueError:
+                    flash(f"Invalid amount for {member_email}", "error")
+                    return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        if not split_details:
+            flash("Please specify amounts for at least one participant", "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+        # Validate custom split
+        is_valid, error_msg = ExpenseService.validate_custom_split(split_details, amount)
+        if not is_valid:
+            flash(error_msg, "error")
+            return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Store old expense values for notification (before update)
+    old_description = expense.description
+    old_amount = expense.amount
+    old_payer = expense.payer
+    editor_name = user.display_name or user.email
+
+    # Create a simple object for notification
+    class ExpenseInfo:
+        def __init__(self, description, amount, payer, participants):
+            self.description = description
+            self.amount = amount
+            self.payer = payer
+            self.participants = participants
+
+    expense_info = ExpenseInfo(description, amount, payer, ", ".join(split_details.keys()))
+
+    # Update expense
+    expense.description = description
+    expense.amount = amount
+    expense.payer = payer
+    expense.split_type = split_type
+    expense.split_details = json.dumps(split_details)
+    expense.participants = ", ".join(split_details.keys())  # Keep for backward compatibility
+    db.session.commit()
+
+    # Send notifications to other group members (excluding the editor)
+    try:
+        notify_expense_edited(expense_info, user.email, group.members)
+    except Exception as e:
+        print(f"Failed to send edit notifications: {e}")
+
+    # Create database notification for all group members to see
+    from models import GroupNotification
+
+    notification = GroupNotification(
+        group_id=group_id,
+        notification_type="expense_edited",
+        description=description,
+        amount=amount,
+        payer=payer,
+        edited_by=editor_name,
+        read_by="[]",  # Empty JSON array - no one has read it yet
+    )
+    db.session.add(notification)
+    db.session.commit()
+
+    flash("Expense updated successfully!", "success")
     return redirect(url_for("groups.group_expenses", group_id=group_id))
 
 

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -83,3 +83,27 @@ def notify_expense_deletion(expense, deleter_email, group_members):
             print(f"Subject: {subject}")
             print(f"\n{body}")
             print("=" * 60 + "\n")
+
+
+def notify_expense_edited(expense, editor_email, group_members):
+    """Print notification to terminal for group members when an expense is edited."""
+    subject = f"Expense edited: {expense.description}"
+    body = (
+        f"An expense has been edited in your group:\n\n"
+        f"Description: {expense.description}\n"
+        f"Amount: ${expense.amount:.2f}\n"
+        f"Paid by: {expense.payer}\n"
+        f"Participants: {expense.participants or 'Not specified'}\n"
+        f"Edited by: {editor_email}\n"
+    )
+
+    # Print notification to terminal for all group members except the editor
+    for member in group_members:
+        if member.email != editor_email:
+            print("\n" + "=" * 60)
+            print("EXPENSE EDIT NOTIFICATION")
+            print("=" * 60)
+            print(f"To: {member.email}")
+            print(f"Subject: {subject}")
+            print(f"\n{body}")
+            print("=" * 60 + "\n")

--- a/templates/groups/expenses.html
+++ b/templates/groups/expenses.html
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="mb-8">
+<div class="mb-6">
     <div class="flex items-center gap-4 mb-4">
         <a href="{{ url_for('groups.list_groups') }}" class="p-2 hover:bg-gray-100 rounded-lg transition-colors">
             <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -101,32 +101,41 @@
 </div>
 {% endif %}
 
-<div class="bg-gradient-to-r from-emerald-50 to-teal-50 rounded-xl p-6 mb-8 border border-emerald-200">
-    <div class="flex items-start gap-3">
-        <span class="text-2xl">💡</span>
-        <div class="flex-1">
-            <h3 class="font-semibold text-gray-900 mb-1">Tech-Forward Finance</h3>
-            <p class="text-gray-600 text-sm">A sleek, professional expense tracker with a modern tech aesthetic. Perfect for hackathons, team projects, or any group financial management.</p>
-        </div>
-        <a href="{{ url_for('expenses.balance_summary', group_id=group.id) }}" class="px-4 py-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-lg hover:from-blue-700 hover:to-indigo-700 transition-all duration-200 font-medium whitespace-nowrap flex items-center gap-2">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
+<!-- Expense Edit Notification Banner -->
+{% if edit_info %}
+<div id="expense-edited-banner" class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+    <div class="flex items-start justify-between">
+        <div class="flex items-start gap-3 flex-1">
+            <svg class="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
             </svg>
-            View Balance
-        </a>
+            <div class="flex-1">
+                <h4 class="text-blue-900 font-semibold mb-2">Expense Edited</h4>
+                <div class="text-sm text-blue-800 space-y-1">
+                    <p><span class="font-medium">Description:</span> {{ edit_info.description }}</p>
+                    <p><span class="font-medium">Amount:</span> ${{ "%.2f"|format(edit_info.amount|float) }}</p>
+                    <p><span class="font-medium">Paid by:</span> {{ email_to_name.get(edit_info.payer, edit_info.payer) }}</p>
+                    <p><span class="font-medium">Edited by:</span> {{ edit_info.edited_by }}</p>
+                </div>
+            </div>
+        </div>
+        <button onclick="markNotificationRead({{ edit_info.notification_id if edit_info and edit_info.notification_id else 'null' }})" class="text-blue-600 hover:text-blue-800 ml-4 flex-shrink-0">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+        </button>
     </div>
 </div>
+{% endif %}
 
-<div class="grid lg:grid-cols-2 gap-8">
-    <div class="bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl shadow-xl border border-cyan-500/20 p-6 text-white">
-        <div class="flex items-center justify-between mb-6">
-            <div class="flex items-center gap-2">
-                <span class="text-xl">⚡</span>
-                <h3 class="text-lg font-semibold">New Transaction</h3>
+<div class="grid lg:grid-cols-[1fr,2.5fr] gap-6">
+    <!-- Add Transaction Form (Compact Sidebar) -->
+    <div class="bg-white rounded-xl shadow-md border border-gray-200 p-5">
+        <div class="flex items-center justify-between mb-5">
+            <h3 class="text-lg font-semibold text-gray-900">Add Transaction</h3>
+            <div class="w-8 h-8 rounded-full bg-gradient-to-br from-emerald-500 to-teal-500 flex items-center justify-center">
+                <span class="text-white text-lg">+</span>
             </div>
-            <span class="text-xs font-mono text-cyan-400 bg-cyan-400/10 px-3 py-1 rounded-full border border-cyan-400/20">
-                TERMINAL.EXPENSE.ADD
-            </span>
         </div>
 
         <form method="POST" action="{{ url_for('groups.group_expenses', group_id=group.id) }}" class="space-y-4" id="expenseForm">
@@ -134,146 +143,179 @@
 
             <!-- Description -->
             <div>
-                <label for="description" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Description *</label>
+                <label for="description" class="block text-sm font-medium text-gray-700 mb-1.5">Description</label>
                 <input type="text" id="description" name="description"
-                    class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
+                    class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 text-gray-900 placeholder-gray-400"
                     placeholder="Project supplies, Team lunch..." required>
             </div>
 
             <!-- Amount and Payer -->
-            <div class="grid grid-cols-2 gap-4">
+            <div class="grid grid-cols-2 gap-3">
                 <div>
-                    <label for="amount" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Amount ($) *</label>
+                    <label for="amount" class="block text-sm font-medium text-gray-700 mb-1.5">Amount</label>
                     <input type="number" id="amount" name="amount" step="0.01" min="0.01"
-                        class="w-full px-4 py-3 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-2xl font-bold text-cyan-300 placeholder-gray-500"
+                        class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 text-gray-900 placeholder-gray-400 font-semibold"
                         placeholder="0.00" required>
                 </div>
                 <div>
-                    <label for="payer" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Paid By *</label>
+                    <label for="payer" class="block text-sm font-medium text-gray-700 mb-1.5">Paid By</label>
                     <select id="payer" name="payer" required
-                        class="w-full px-4 py-3 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white">
-                        <option value="">Select payer...</option>
+                        class="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 text-gray-900">
+                        <option value="">Select...</option>
                     </select>
                 </div>
             </div>
 
             <!-- Split Type -->
             <div>
-                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Split Type *</label>
-                <div class="flex gap-4">
-                    <label class="flex items-center">
-                        <input type="radio" name="split_type" value="equal" checked class="mr-2">
-                        <span class="text-sm">Equal Split</span>
+                <label class="block text-sm font-medium text-gray-700 mb-1.5">Split Type</label>
+                <div class="flex gap-3">
+                    <label class="flex items-center cursor-pointer">
+                        <input type="radio" name="split_type" value="equal" checked class="mr-2 text-emerald-500 focus:ring-emerald-500">
+                        <span class="text-sm text-gray-700">Equal</span>
                     </label>
-                    <label class="flex items-center">
-                        <input type="radio" name="split_type" value="custom" class="mr-2">
-                        <span class="text-sm">Custom Split</span>
+                    <label class="flex items-center cursor-pointer">
+                        <input type="radio" name="split_type" value="custom" class="mr-2 text-emerald-500 focus:ring-emerald-500">
+                        <span class="text-sm text-gray-700">Custom</span>
                     </label>
                 </div>
             </div>
 
             <!-- Participants Selection (Equal Split) -->
             <div id="equalSplitOptions" class="split-option active">
-                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Participants *</label>
-                <div id="participantsList" class="space-y-2">
-                    <p class="text-sm text-gray-400">Select a group first to see members</p>
+                <label class="block text-sm font-medium text-gray-700 mb-1.5">Participants</label>
+                <div id="participantsList" class="space-y-2 bg-gray-50 rounded-lg p-3 max-h-32 overflow-y-auto">
+                    <p class="text-xs text-gray-500">Loading members...</p>
                 </div>
-                <div id="equalSplitSummary" class="mt-2 text-sm text-cyan-300" style="display: none;">
+                <div id="equalSplitSummary" class="mt-2 text-xs text-emerald-600 font-medium" style="display: none;">
                     <span id="splitAmount">$0.00</span> per person
                 </div>
             </div>
 
             <!-- Custom Split Options -->
             <div id="customSplitOptions" class="split-option">
-                <label class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Custom Amounts *</label>
-                <div id="customAmountsList" class="space-y-2">
-                    <p class="text-sm text-gray-400">Select a group first to see members</p>
+                <label class="block text-sm font-medium text-gray-700 mb-1.5">Custom Amounts</label>
+                <div id="customAmountsList" class="space-y-2 bg-gray-50 rounded-lg p-3 max-h-32 overflow-y-auto">
+                    <p class="text-xs text-gray-500">Loading members...</p>
                 </div>
-                <div id="customSplitSummary" class="mt-2 text-sm text-cyan-300" style="display: none;">
-                    Total: $<span id="customTotal">0.00</span> / $<span id="customExpected">0.00</span>
+                <div id="customSplitSummary" class="mt-2 text-xs font-medium" style="display: none;">
+                    Total: $<span id="customTotal" class="text-gray-700">0.00</span> / $<span id="customExpected" class="text-gray-700">0.00</span>
                 </div>
             </div>
 
             <button type="submit"
-                class="w-full bg-gradient-to-r from-cyan-500 to-teal-500 text-slate-900 py-3 rounded-lg font-bold hover:from-cyan-400 hover:to-teal-400 transform hover:scale-[1.02] transition-all duration-200 shadow-lg uppercase tracking-wider flex items-center justify-center gap-2">
-                <span class="text-xl">+</span>
-                COMMIT TRANSACTION
+                class="w-full bg-gradient-to-r from-emerald-500 to-teal-500 text-white py-2.5 rounded-lg font-medium hover:from-emerald-600 hover:to-teal-600 transform hover:scale-[1.01] transition-all duration-200 shadow-md flex items-center justify-center gap-2">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+                </svg>
+                Add Transaction
             </button>
         </form>
     </div>
 
-    <div class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+    <!-- Transactions Section (Main Content) -->
+    <div class="bg-white rounded-xl shadow-md border border-gray-200 p-6">
         <div class="flex items-center justify-between mb-6">
-            <div class="flex items-center gap-2">
-                <span class="text-xl">📊</span>
-                <h3 class="text-lg font-semibold text-gray-900">Transaction Log</h3>
+            <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-emerald-500 to-teal-500 flex items-center justify-center">
+                    <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+                    </svg>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-900">Transactions</h3>
+                    <p class="text-sm text-gray-500">{{ transaction_count }} transaction{{ 's' if transaction_count != 1 else '' }} total</p>
+                </div>
             </div>
-            <span class="text-xs font-mono text-emerald-600 bg-emerald-100 px-3 py-1 rounded-full pulse-animation">
-                BALANCE: CALCULATING...
-            </span>
+            <a href="{{ url_for('expenses.balance_summary', group_id=group.id) }}" class="flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors font-medium text-sm" title="View Balance">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
+                </svg>
+                Balance
+            </a>
         </div>
 
         {% if expenses %}
-            <div class="space-y-3 max-h-96 overflow-y-auto">
+            <div class="space-y-4 overflow-y-auto" style="max-height: calc(100vh - 350px);">
                 {% for item in expenses %}
                     {% set expense = item.model %}
-                <div class="group relative bg-gradient-to-r from-slate-50 to-gray-50 rounded-xl border border-gray-200 p-4 hover:shadow-md transition-all duration-200">
-                    <span class="absolute -top-2 right-4 text-xs font-mono font-bold bg-gradient-to-r from-cyan-500 to-teal-500 text-white px-2 py-1 rounded">
-                        #{{ loop.index }}
-                    </span>
-
-                    <div class="flex items-start justify-between mb-3">
-                        <div>
-                            <h4 class="font-semibold text-gray-900">{{ expense.description }}</h4>
-                            <div class="flex items-center gap-2 mt-1">
-                                <span class="text-xs font-mono bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded">
-                                    @{{ email_to_name.get(expense.payer, expense.payer) }}
+                <div class="group relative bg-white rounded-xl border-2 border-gray-200 hover:border-emerald-300 hover:shadow-lg transition-all duration-300 overflow-hidden" 
+                     data-expense-id="{{ expense.id }}"
+                     data-expense='{"id": {{ expense.id }}, "description": "{{ expense.description|replace('"', '\\"') }}", "amount": {{ expense.amount }}, "payer": "{{ expense.payer }}", "split_type": "{{ expense.split_type }}", "split_details": {{ item.split_details|tojson|safe }}}'>
+                    <div class="expense-view p-5">
+                    <!-- Header with amount and badge -->
+                    <div class="flex items-start justify-between mb-4">
+                        <div class="flex-1">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-br from-emerald-500 to-teal-500 text-white text-xs font-bold">
+                                    {{ loop.index }}
                                 </span>
-                                <span class="text-xs text-gray-400 font-mono">
-                                    {{ expense.created_at.strftime('%Y-%m-%d %H:%M') }}
+                                <h4 class="text-lg font-bold text-gray-900">{{ expense.description }}</h4>
+                            </div>
+                            <div class="flex items-center gap-2 mt-2">
+                                <span class="inline-flex items-center gap-1.5 px-2.5 py-1 bg-emerald-50 text-emerald-700 rounded-full text-xs font-medium">
+                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+                                    </svg>
+                                    {{ email_to_name.get(expense.payer, expense.payer) }}
+                                </span>
+                                <span class="text-xs text-gray-500">
+                                    {{ expense.created_at.strftime('%b %d, %Y at %I:%M %p') }}
                                 </span>
                             </div>
                         </div>
-                        <div class="text-right">
-                            <span class="text-2xl font-bold font-mono text-emerald-600">
+                        <div class="text-right ml-4">
+                            <div class="text-3xl font-bold text-emerald-600 mb-1">
                                 ${{ '%.2f' % expense.amount }}
-                            </span>
+                            </div>
                         </div>
                     </div>
 
+                    <!-- Participants and Split Details -->
                     {% if item.participants %}
-                        <div class="border-t border-gray-200 pt-3">
-                            <div class="flex items-center justify-between">
-                                <div class="flex flex-wrap gap-1">
+                        <div class="border-t border-gray-100 pt-4 mt-4">
+                            <div class="flex flex-col gap-3">
+                                <div class="flex flex-wrap gap-2">
+                                    <span class="text-xs font-medium text-gray-500 uppercase tracking-wide">Participants:</span>
                                     {% for p in item.participants %}
-                                        <span class="text-xs font-mono bg-cyan-100 text-cyan-700 px-2 py-0.5 rounded">
+                                        <span class="inline-flex items-center px-2.5 py-1 bg-blue-50 text-blue-700 rounded-full text-xs font-medium">
                                             @{{ email_to_name.get(p, p) }}
                                         </span>
                                     {% endfor %}
                                 </div>
                                 {% if item.split_details %}
-                                    <div class="text-sm font-mono text-gray-600">
+                                    <div class="grid grid-cols-2 gap-2 mt-1">
                                         {% for participant, amount in item.split_details.items() %}
-                                            <span class="block">{{ email_to_name.get(participant, participant) }}: ${{ '%.2f' % amount }}</span>
+                                            <div class="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg">
+                                                <span class="text-sm text-gray-700">{{ email_to_name.get(participant, participant) }}</span>
+                                                <span class="text-sm font-semibold text-gray-900">${{ '%.2f' % amount }}</span>
+                                            </div>
                                         {% endfor %}
                                     </div>
                                 {% elif item.share is not none %}
-                                    <span class="text-sm font-mono text-gray-600">
-                                        Each: <span class="font-bold text-cyan-600">${{ '%.2f' % item.share }}</span>
-                                    </span>
+                                    <div class="px-3 py-2 bg-emerald-50 rounded-lg border border-emerald-200">
+                                        <span class="text-sm text-gray-600">Each person owes: </span>
+                                        <span class="text-sm font-bold text-emerald-700">${{ '%.2f' % item.share }}</span>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>
                     {% else %}
-                        <div class="border-t border-gray-200 pt-3">
-                            <span class="text-xs font-mono text-gray-400">[NO SPLIT DEFINED]</span>
+                        <div class="border-t border-gray-100 pt-4 mt-4">
+                            <span class="text-xs text-gray-400 italic">No split defined</span>
                         </div>
                     {% endif %}
 
-                    <!-- Delete Button -->
-                    <div class="border-t border-gray-200 pt-3 mt-3">
-                        <form action="{{ url_for('groups.delete_expense', group_id=group.id, expense_id=expense.id) }}" method="POST" class="inline" onsubmit="return confirm('Are you sure you want to delete this expense? This action cannot be undone.');">
-                            <button type="submit" class="text-xs font-mono bg-red-100 text-red-700 hover:bg-red-200 px-3 py-1.5 rounded transition-colors flex items-center gap-1">
+                    <!-- Action Buttons -->
+                    <div class="flex items-center gap-2 mt-5 pt-4 border-t border-gray-100">
+                        <button onclick="toggleEditMode({{ expense.id }})" class="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-blue-50 hover:bg-blue-100 text-blue-700 rounded-lg transition-colors font-medium text-sm">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                            </svg>
+                            Edit
+                        </button>
+                        <form action="{{ url_for('groups.delete_expense', group_id=group.id, expense_id=expense.id) }}" method="POST" class="inline flex-1" onsubmit="return confirm('Are you sure you want to delete this expense? This action cannot be undone.');">
+                            <button type="submit" class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-red-50 hover:bg-red-100 text-red-700 rounded-lg transition-colors font-medium text-sm">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
                                 </svg>
@@ -281,26 +323,100 @@
                             </button>
                         </form>
                     </div>
+                    </div>
+                </div>
+                
+                <!-- Inline Edit Form (Hidden by default) -->
+                <div id="edit-form-{{ expense.id }}" class="hidden mt-4 bg-gray-50 rounded-xl border-2 border-gray-300 p-5">
+                    <form method="POST" action="{{ url_for('groups.edit_expense', group_id=group.id, expense_id=expense.id) }}" class="space-y-4" id="editExpenseForm-{{ expense.id }}">
+                        <h5 class="text-sm font-semibold text-gray-700 mb-4">Edit Transaction</h5>
+                        <!-- Description -->
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1.5">Description</label>
+                            <input type="text" name="description" id="edit-description-{{ expense.id }}"
+                                class="w-full px-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 text-gray-900 placeholder-gray-400"
+                                placeholder="Project supplies, Team lunch..." required>
+                        </div>
+
+                        <!-- Amount and Payer -->
+                        <div class="grid grid-cols-2 gap-3">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1.5">Amount</label>
+                                <input type="number" name="amount" id="edit-amount-{{ expense.id }}" step="0.01" min="0.01"
+                                    class="w-full px-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 text-gray-900 placeholder-gray-400 font-semibold"
+                                    placeholder="0.00" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1.5">Paid By</label>
+                                <select name="payer" id="edit-payer-{{ expense.id }}" required
+                                    class="w-full px-3 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all duration-200 text-gray-900">
+                                    <option value="">Select...</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <!-- Split Type -->
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1.5">Split Type</label>
+                            <div class="flex gap-3">
+                                <label class="flex items-center cursor-pointer">
+                                    <input type="radio" name="split_type" value="equal" id="edit-split-equal-{{ expense.id }}" class="mr-2 text-emerald-500 focus:ring-emerald-500">
+                                    <span class="text-sm text-gray-700">Equal</span>
+                                </label>
+                                <label class="flex items-center cursor-pointer">
+                                    <input type="radio" name="split_type" value="custom" id="edit-split-custom-{{ expense.id }}" class="mr-2 text-emerald-500 focus:ring-emerald-500">
+                                    <span class="text-sm text-gray-700">Custom</span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <!-- Participants Selection (Equal Split) -->
+                        <div id="edit-equalSplitOptions-{{ expense.id }}" class="split-option">
+                            <label class="block text-sm font-medium text-gray-700 mb-1.5">Participants</label>
+                            <div id="edit-participantsList-{{ expense.id }}" class="space-y-2 bg-white rounded-lg p-3 max-h-32 overflow-y-auto border border-gray-300">
+                                <!-- Populated by JavaScript -->
+                            </div>
+                            <div id="edit-equalSplitSummary-{{ expense.id }}" class="mt-2 text-xs text-emerald-600 font-medium" style="display: none;">
+                                <span id="edit-splitAmount-{{ expense.id }}">$0.00</span> per person
+                            </div>
+                        </div>
+
+                        <!-- Custom Split Options -->
+                        <div id="edit-customSplitOptions-{{ expense.id }}" class="split-option" style="display: none;">
+                            <label class="block text-sm font-medium text-gray-700 mb-1.5">Custom Amounts</label>
+                            <div id="edit-customAmountsList-{{ expense.id }}" class="space-y-2 bg-white rounded-lg p-3 max-h-32 overflow-y-auto border border-gray-300">
+                                <!-- Populated by JavaScript -->
+                            </div>
+                            <div id="edit-customSplitSummary-{{ expense.id }}" class="mt-2 text-xs font-medium" style="display: none;">
+                                Total: $<span id="edit-customTotal-{{ expense.id }}" class="text-gray-700">0.00</span> / $<span id="edit-customExpected-{{ expense.id }}" class="text-gray-700">0.00</span>
+                            </div>
+                        </div>
+
+                        <div class="flex gap-2 pt-2">
+                            <button type="submit"
+                                class="flex-1 bg-gradient-to-r from-emerald-500 to-teal-500 text-white py-2.5 rounded-lg font-medium hover:from-emerald-600 hover:to-teal-600 transform hover:scale-[1.01] transition-all duration-200 shadow-md flex items-center justify-center gap-2">
+                                Save Changes
+                            </button>
+                            <button type="button" onclick="cancelEditMode({{ expense.id }})"
+                                class="flex-1 bg-gray-200 text-gray-700 py-2.5 rounded-lg font-medium hover:bg-gray-300 transform hover:scale-[1.01] transition-all duration-200 flex items-center justify-center gap-2">
+                                Cancel
+                            </button>
+                        </div>
+                    </form>
                 </div>
                 {% endfor %}
             </div>
         {% else %}
-            <div class="text-center py-12">
-                <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-emerald-100 to-teal-100 rounded-full mb-4">
-                    <span class="text-2xl font-mono text-emerald-600">></span>
-                    <span class="text-2xl font-mono text-emerald-600 pulse-animation">_</span>
+            <div class="text-center py-16">
+                <div class="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-emerald-100 to-teal-100 rounded-2xl mb-6">
+                    <svg class="w-10 h-10 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                    </svg>
                 </div>
-                <p class="text-gray-500 font-mono mb-2">AWAITING FIRST TRANSACTION...</p>
-                <p class="text-sm text-gray-400">Initialize the expense log by adding your first transaction above.</p>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">No transactions yet</h3>
+                <p class="text-gray-500 mb-6">Get started by adding your first transaction using the form on the left.</p>
             </div>
         {% endif %}
-    </div>
-</div>
-
-<div class="mt-8 bg-gradient-to-r from-emerald-600 to-teal-600 rounded-xl p-8 text-white">
-    <div class="max-w-3xl mx-auto text-center">
-        <h3 class="text-2xl font-bold mb-2">Pro Tip</h3>
-        <p class="opacity-90">Split expenses fairly! Studies show that transparent expense tracking improves team collaboration by 35%.</p>
     </div>
 </div>
 
@@ -343,8 +459,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 const div = document.createElement('div');
                 div.className = 'flex items-center';
                 div.innerHTML = `
-                    <input type="checkbox" name="participants" value="${member.email}" id="participant_${member.email}" class="mr-2" checked>
-                    <label for="participant_${member.email}" class="text-sm">${member.display_name}</label>
+                    <label class="flex items-center cursor-pointer">
+                        <input type="checkbox" name="participants" value="${member.email}" id="participant_${member.email}" class="mr-2 w-4 h-4 text-emerald-500 border-gray-300 rounded focus:ring-emerald-500" checked>
+                        <span class="text-sm text-gray-700">${member.display_name}</span>
+                    </label>
                 `;
                 participantsList.appendChild(div);
             });
@@ -353,11 +471,11 @@ document.addEventListener('DOMContentLoaded', function() {
             customAmountsList.innerHTML = '';
             members.forEach(member => {
                 const div = document.createElement('div');
-                div.className = 'flex items-center gap-2';
+                div.className = 'flex items-center justify-between gap-3';
                 div.innerHTML = `
-                    <label class="text-sm w-20">${member.display_name}:</label>
+                    <label class="text-sm text-gray-700 font-medium">${member.display_name}:</label>
                     <input type="number" name="custom_amount_${member.email}" step="0.01" min="0" 
-                           class="flex-1 px-2 py-1 bg-slate-950/50 border border-cyan-500/30 rounded text-sm custom-amount-input">
+                           class="w-24 px-2 py-1.5 bg-white border border-gray-300 rounded text-sm custom-amount-input focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-gray-900">
                 `;
                 customAmountsList.appendChild(div);
             });
@@ -424,9 +542,9 @@ document.addEventListener('DOMContentLoaded', function() {
             if (amount > 0) {
                 customSplitSummary.style.display = 'block';
                 if (Math.abs(total - amount) < 0.01) {
-                    customSplitSummary.className = 'mt-2 text-sm text-green-300';
+                    customSplitSummary.className = 'mt-2 text-xs font-medium text-emerald-600';
                 } else {
-                    customSplitSummary.className = 'mt-2 text-sm text-red-300';
+                    customSplitSummary.className = 'mt-2 text-xs font-medium text-red-600';
                 }
             } else {
                 customSplitSummary.style.display = 'none';
@@ -485,10 +603,14 @@ document.addEventListener('DOMContentLoaded', function() {
 <script>
 // Mark notification as read when banner is dismissed (global function for onclick handler)
 function markNotificationRead(notificationId) {
-    // Hide banner immediately
-    const banner = document.getElementById('expense-deleted-banner');
-    if (banner) {
-        banner.style.display = 'none';
+    // Hide both banners immediately
+    const deletedBanner = document.getElementById('expense-deleted-banner');
+    const editedBanner = document.getElementById('expense-edited-banner');
+    if (deletedBanner) {
+        deletedBanner.style.display = 'none';
+    }
+    if (editedBanner) {
+        editedBanner.style.display = 'none';
     }
     
     // Mark as read in database
@@ -501,6 +623,242 @@ function markNotificationRead(notificationId) {
         }).catch(error => {
             console.error('Failed to mark notification as read:', error);
         });
+    }
+}
+
+// Toggle edit mode for an expense
+function toggleEditMode(expenseId) {
+    const expenseCard = document.querySelector(`[data-expense-id="${expenseId}"]`);
+    const editForm = document.getElementById(`edit-form-${expenseId}`);
+    const expenseView = expenseCard?.querySelector('.expense-view');
+    
+    if (!expenseCard || !editForm || !expenseView) return;
+    
+    // Hide expense view, show edit form
+    expenseView.style.display = 'none';
+    editForm.classList.remove('hidden');
+    
+    // Populate form with current expense data
+    populateEditForm(expenseId);
+}
+
+// Cancel edit mode
+function cancelEditMode(expenseId) {
+    const expenseCard = document.querySelector(`[data-expense-id="${expenseId}"]`);
+    const editForm = document.getElementById(`edit-form-${expenseId}`);
+    const expenseView = expenseCard?.querySelector('.expense-view');
+    
+    if (!expenseCard || !editForm || !expenseView) return;
+    
+    // Show expense view, hide edit form
+    expenseView.style.display = 'block';
+    editForm.classList.add('hidden');
+}
+
+// Populate edit form with current expense data
+function populateEditForm(expenseId) {
+    const expenseCard = document.querySelector(`[data-expense-id="${expenseId}"]`);
+    if (!expenseCard) return;
+    
+    // Get expense data from data attributes or template context
+    const expenseData = JSON.parse(expenseCard.getAttribute('data-expense') || '{}');
+    
+    // Populate basic fields
+    const descriptionInput = document.getElementById(`edit-description-${expenseId}`);
+    const amountInput = document.getElementById(`edit-amount-${expenseId}`);
+    const payerSelect = document.getElementById(`edit-payer-${expenseId}`);
+    
+    if (descriptionInput && expenseData.description) {
+        descriptionInput.value = expenseData.description;
+    }
+    if (amountInput && expenseData.amount) {
+        amountInput.value = expenseData.amount;
+    }
+    
+    // Populate payer dropdown with group members
+    if (payerSelect) {
+        const groups = JSON.parse('{{ groups_data|tojson|safe }}') || [];
+        const currentGroup = groups.find(g => g.id === {{ group.id }});
+        if (currentGroup) {
+            payerSelect.innerHTML = '<option value="">Select payer...</option>';
+            currentGroup.members.forEach(member => {
+                const option = document.createElement('option');
+                option.value = member.email;
+                option.textContent = member.display_name || member.email;
+                if (expenseData.payer === member.email) {
+                    option.selected = true;
+                }
+                payerSelect.appendChild(option);
+            });
+        }
+    }
+    
+    // Populate split type
+    const splitType = expenseData.split_type || 'equal';
+    document.getElementById(`edit-split-equal-${expenseId}`).checked = splitType === 'equal';
+    document.getElementById(`edit-split-custom-${expenseId}`).checked = splitType === 'custom';
+    
+    // Show/hide split options
+    const equalOptions = document.getElementById(`edit-equalSplitOptions-${expenseId}`);
+    const customOptions = document.getElementById(`edit-customSplitOptions-${expenseId}`);
+    
+    if (splitType === 'equal') {
+        equalOptions.style.display = 'block';
+        customOptions.style.display = 'none';
+    } else {
+        equalOptions.style.display = 'none';
+        customOptions.style.display = 'block';
+    }
+    
+    // Populate participants and custom amounts
+    populateEditParticipants(expenseId, expenseData);
+    
+    // Setup event listeners for edit form
+    setupEditFormListeners(expenseId);
+}
+
+// Populate participants and custom amounts in edit form
+function populateEditParticipants(expenseId, expenseData) {
+    const groups = JSON.parse('{{ groups_data|tojson|safe }}') || [];
+    const currentGroup = groups.find(g => g.id === {{ group.id }});
+    if (!currentGroup) return;
+    
+    const splitType = expenseData.split_type || 'equal';
+    const splitDetails = expenseData.split_details || {};
+    const participantsList = document.getElementById(`edit-participantsList-${expenseId}`);
+    const customAmountsList = document.getElementById(`edit-customAmountsList-${expenseId}`);
+    
+    if (splitType === 'equal' && participantsList) {
+        participantsList.innerHTML = '';
+        currentGroup.members.forEach(member => {
+            const isChecked = Object.keys(splitDetails).includes(member.email);
+            const checkbox = document.createElement('div');
+            checkbox.className = 'flex items-center';
+            checkbox.innerHTML = `
+                <label class="flex items-center cursor-pointer">
+                    <input type="checkbox" name="participants" value="${member.email}" 
+                           ${isChecked ? 'checked' : ''} class="mr-2 w-4 h-4 text-emerald-500 border-gray-300 rounded focus:ring-emerald-500">
+                    <span class="text-sm text-gray-700">${member.display_name || member.email}</span>
+                </label>
+            `;
+            participantsList.appendChild(checkbox);
+        });
+        updateEditSplitCalculations(expenseId);
+    } else if (splitType === 'custom' && customAmountsList) {
+        customAmountsList.innerHTML = '';
+        currentGroup.members.forEach(member => {
+            const amount = splitDetails[member.email] || '';
+            const inputDiv = document.createElement('div');
+            inputDiv.className = 'flex items-center justify-between gap-3';
+            inputDiv.innerHTML = `
+                <label class="text-sm text-gray-700 font-medium">${member.display_name || member.email}:</label>
+                <input type="number" name="custom_amount_${member.email}" 
+                       value="${amount}" step="0.01" min="0"
+                       class="w-24 px-2 py-1.5 bg-white border border-gray-300 rounded text-sm custom-amount-input focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-gray-900">
+            `;
+            customAmountsList.appendChild(inputDiv);
+        });
+        updateEditSplitCalculations(expenseId);
+    }
+}
+
+// Setup event listeners for edit form
+function setupEditFormListeners(expenseId) {
+    const amountInput = document.getElementById(`edit-amount-${expenseId}`);
+    const splitTypeRadios = [
+        document.getElementById(`edit-split-equal-${expenseId}`),
+        document.getElementById(`edit-split-custom-${expenseId}`)
+    ];
+    const participantsList = document.getElementById(`edit-participantsList-${expenseId}`);
+    const customAmountsList = document.getElementById(`edit-customAmountsList-${expenseId}`);
+    
+    // Amount change
+    if (amountInput) {
+        amountInput.addEventListener('input', () => updateEditSplitCalculations(expenseId));
+    }
+    
+    // Split type change
+    splitTypeRadios.forEach(radio => {
+        if (radio) {
+            radio.addEventListener('change', function() {
+                const equalOptions = document.getElementById(`edit-equalSplitOptions-${expenseId}`);
+                const customOptions = document.getElementById(`edit-customSplitOptions-${expenseId}`);
+                const expenseData = JSON.parse(
+                    document.querySelector(`[data-expense-id="${expenseId}"]`)?.getAttribute('data-expense') || '{}'
+                );
+                
+                if (this.value === 'equal') {
+                    equalOptions.style.display = 'block';
+                    customOptions.style.display = 'none';
+                } else {
+                    equalOptions.style.display = 'none';
+                    customOptions.style.display = 'block';
+                }
+                populateEditParticipants(expenseId, {...expenseData, split_type: this.value});
+                updateEditSplitCalculations(expenseId);
+            });
+        }
+    });
+    
+    // Participant selection change
+    if (participantsList) {
+        participantsList.addEventListener('change', () => updateEditSplitCalculations(expenseId));
+    }
+    
+    // Custom amount changes
+    if (customAmountsList) {
+        customAmountsList.addEventListener('input', function(e) {
+            if (e.target.classList.contains('custom-amount-input')) {
+                updateEditSplitCalculations(expenseId);
+            }
+        });
+    }
+}
+
+// Update split calculations for edit form
+function updateEditSplitCalculations(expenseId) {
+    const amountInput = document.getElementById(`edit-amount-${expenseId}`);
+    const amount = parseFloat(amountInput?.value) || 0;
+    const splitType = document.querySelector(`input[name="split_type"]:checked`, 
+        document.getElementById(`edit-form-${expenseId}`))?.value || 'equal';
+    
+    if (splitType === 'equal') {
+        const checkboxes = document.querySelectorAll(`#edit-participantsList-${expenseId} input[type="checkbox"]:checked`);
+        const participantCount = checkboxes.length;
+        const splitAmount = document.getElementById(`edit-splitAmount-${expenseId}`);
+        const summary = document.getElementById(`edit-equalSplitSummary-${expenseId}`);
+        
+        if (participantCount > 0 && amount > 0) {
+            const share = amount / participantCount;
+            if (splitAmount) splitAmount.textContent = '$' + share.toFixed(2);
+            if (summary) summary.style.display = 'block';
+        } else {
+            if (summary) summary.style.display = 'none';
+        }
+    } else {
+        const customInputs = document.querySelectorAll(`#edit-customAmountsList-${expenseId} .custom-amount-input`);
+        let total = 0;
+        customInputs.forEach(input => {
+            total += parseFloat(input.value) || 0;
+        });
+        
+        const customTotal = document.getElementById(`edit-customTotal-${expenseId}`);
+        const customExpected = document.getElementById(`edit-customExpected-${expenseId}`);
+        const summary = document.getElementById(`edit-customSplitSummary-${expenseId}`);
+        
+        if (customTotal) customTotal.textContent = total.toFixed(2);
+        if (customExpected) customExpected.textContent = amount.toFixed(2);
+        
+        if (amount > 0 && summary) {
+            summary.style.display = 'block';
+            if (Math.abs(total - amount) < 0.01) {
+                summary.className = 'mt-2 text-sm text-green-600';
+            } else {
+                summary.className = 'mt-2 text-sm text-red-600';
+            }
+        } else if (summary) {
+            summary.style.display = 'none';
+        }
     }
 }
 </script>

--- a/tests/test_group_routes.py
+++ b/tests/test_group_routes.py
@@ -1353,3 +1353,1354 @@ def test_mark_notification_read_notification_not_found(client, app):
 
     # Assert - should redirect
     assert response.status_code == 302
+
+
+# Edit Expense Tests
+
+
+def test_edit_expense_success(client, app):
+    """Test that any group member can edit an expense."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - edit expense
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "editor@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=False
+    )
+
+    # Assert
+    assert response.status_code == 302
+    updated_expense = Expense.query.get(expense_id)
+    assert updated_expense is not None
+    assert updated_expense.description == "Dinner"
+    assert updated_expense.amount == 50.0
+    assert updated_expense.payer == "editor@example.com"
+
+
+def test_edit_expense_requires_login(client, app):
+    """Test that unauthenticated users cannot edit expenses."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    db.session.add(payer)
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.append(payer)
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 30.0}',
+        participants="payer@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    # Act - no login session
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "equal",
+            "participants": ["payer@example.com"],
+        },
+        follow_redirects=False,
+    )
+
+    # Assert - should redirect to login
+    assert response.status_code == 302
+    expense = Expense.query.get(expense_id)
+    assert expense.description == "Lunch"  # Should not be changed
+
+
+def test_edit_expense_requires_membership(client, app):
+    """Test that non-group members cannot edit expenses."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    non_member = User(email="nonmember@example.com")
+    db.session.add_all([payer, non_member])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.append(payer)
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 30.0}',
+        participants="payer@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = non_member.id
+        sess["user_email"] = non_member.email
+
+    # Act
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "equal",
+            "participants": ["payer@example.com"],
+        },
+        follow_redirects=True,
+    )
+
+    # Assert - should redirect with error
+    assert response.status_code == 200
+    assert b"You are not a member of this group" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.description == "Lunch"  # Should not be changed
+
+
+def test_edit_expense_not_found(client, app):
+    """Test that editing non-existent expense returns error."""
+    # Arrange
+    from extensions import db
+
+    payer = User(email="payer@example.com")
+    db.session.add(payer)
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.append(payer)
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    # Act - try to edit non-existent expense
+    response = client.post(
+        f"/groups/{group.id}/expense/99999/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "equal",
+            "participants": ["payer@example.com"],
+        },
+        follow_redirects=True,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Expense not found" in response.data
+
+
+def test_edit_expense_wrong_group(client, app):
+    """Test that editing expense from different group fails."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group1 = Group(name="Group 1", created_by_id=payer.id)
+    group1.members.extend([payer, editor])
+    group2 = Group(name="Group 2", created_by_id=payer.id)
+    group2.members.append(payer)
+    db.session.add_all([group1, group2])
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group1.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 30.0}',
+        participants="payer@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    # Act - try to edit expense from group1 while accessing group2
+    response = client.post(
+        f"/groups/{group2.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "equal",
+            "participants": ["payer@example.com"],
+        },
+        follow_redirects=True,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Expense does not belong to this group" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.description == "Lunch"  # Should not be changed
+
+
+def test_edit_expense_negative_amount(client, app):
+    """Test that editing expense with negative amount fails."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with negative amount
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "-10.00"),
+            ("payer", "payer@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Amount must be greater than zero" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.amount == 30.0  # Should not be changed
+
+
+def test_edit_expense_zero_amount(client, app):
+    """Test that editing expense with zero amount fails."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with zero amount
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "0.00"),
+            ("payer", "payer@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Amount must be greater than zero" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.amount == 30.0  # Should not be changed
+
+
+def test_edit_expense_invalid_payer(client, app):
+    """Test that editing with payer not in group fails."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    non_member = User(email="nonmember@example.com")
+    db.session.add_all([payer, editor, non_member])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with non-member as payer
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "nonmember@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Payer must be a member of the group" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.payer == "payer@example.com"  # Should not be changed
+
+
+def test_edit_expense_invalid_participants(client, app):
+    """Test that editing with participants not in group fails."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    non_member = User(email="nonmember@example.com")
+    db.session.add_all([payer, editor, non_member])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with non-member as participant
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "payer@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "nonmember@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"not in the group" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.description == "Lunch"  # Should not be changed
+
+
+def test_edit_expense_invalid_split_sum(client, app):
+    """Test that editing with custom split not summing to amount fails."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with custom split that doesn't sum to amount
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "custom",
+            "custom_amount_payer@example.com": "30.00",
+            "custom_amount_editor@example.com": "15.00",  # Total = 45, but amount = 50
+        },
+        follow_redirects=True,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"must equal total amount" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.amount == 30.0  # Should not be changed
+
+
+def test_edit_expense_updates_database(client, app):
+    """Test that editing expense updates the database correctly."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    import json
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner at restaurant"),
+            ("amount", "75.50"),
+            ("payer", "editor@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=False
+    )
+
+    # Assert
+    assert response.status_code == 302
+    updated_expense = Expense.query.get(expense_id)
+    assert updated_expense is not None
+    assert updated_expense.description == "Dinner at restaurant"
+    assert updated_expense.amount == 75.5
+    assert updated_expense.payer == "editor@example.com"
+    assert updated_expense.split_type == "equal"
+    split_details = json.loads(updated_expense.split_details)
+    assert len(split_details) == 2
+    assert split_details["payer@example.com"] == 37.75
+    assert split_details["editor@example.com"] == 37.75
+
+
+def test_edit_expense_creates_notification(client, app):
+    """Test that editing an expense creates a database notification."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense, GroupNotification
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "editor@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=False
+    )
+
+    # Assert
+    assert response.status_code == 302
+    notification = GroupNotification.query.filter_by(
+        group_id=group.id, notification_type="expense_edited"
+    ).first()
+    assert notification is not None
+    assert notification.description == "Dinner"
+    assert notification.amount == 50.0
+    assert notification.payer == "editor@example.com"
+    assert notification.edited_by == editor.email
+
+
+def test_group_member_sees_edit_notification(client, app):
+    """Test that group members see edit notification banner."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense, GroupNotification
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    viewer = User(email="viewer@example.com")
+    db.session.add_all([payer, editor, viewer])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor, viewer])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    # Edit expense as editor
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "editor@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    client.post(f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data)
+
+    # View as viewer
+    with client.session_transaction() as sess:
+        sess["user_id"] = viewer.id
+        sess["user_email"] = viewer.email
+
+    # Act
+    response = client.get(f"/groups/{group.id}", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Expense Edited" in response.data
+    assert b"Dinner" in response.data
+    assert b"$50.00" in response.data
+    assert b"editor@example.com" in response.data
+
+
+def test_edit_expense_sends_notifications(client, app):
+    """Test that editing expense sends terminal notifications to other members."""
+    # Arrange
+    from unittest.mock import patch
+    from io import StringIO
+
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    member = User(email="member@example.com")
+    db.session.add_all([payer, editor, member])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor, member])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - capture print output
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "editor@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    output = StringIO()
+    with patch("sys.stdout", output):
+        response = client.post(
+            f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=False
+        )
+
+    printed_output = output.getvalue()
+
+    # Assert
+    assert response.status_code == 302
+    assert "EXPENSE EDIT NOTIFICATION" in printed_output
+    assert "Dinner" in printed_output
+    assert "$50.00" in printed_output
+    assert "To: payer@example.com" in printed_output
+    assert "To: member@example.com" in printed_output
+
+
+def test_edit_expense_no_notification_to_editor(client, app):
+    """Test that editor does not receive terminal notification."""
+    # Arrange
+    from unittest.mock import patch
+    from io import StringIO
+
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - capture print output
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "editor@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    output = StringIO()
+    with patch("sys.stdout", output):
+        response = client.post(
+            f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=False
+        )
+
+    printed_output = output.getvalue()
+
+    # Assert
+    assert response.status_code == 302
+    assert "To: editor@example.com" not in printed_output
+    assert "To: payer@example.com" in printed_output
+
+
+def test_edit_expense_handles_notification_error(client, app):
+    """Test that expense editing continues even if notification fails."""
+    # Arrange
+    from unittest.mock import patch
+
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense, GroupNotification
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - Simulate notification failure
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", "editor@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    with patch("routes.groups.notify_expense_edited", side_effect=Exception("Notification error")):
+        response = client.post(
+            f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=False
+        )
+
+    # Assert - Expense should still be updated and notification should be created
+    assert response.status_code == 302
+    updated_expense = Expense.query.get(expense_id)
+    assert updated_expense is not None
+    assert updated_expense.description == "Dinner"
+    notification = GroupNotification.query.filter_by(
+        group_id=group.id, notification_type="expense_edited"
+    ).first()
+    assert notification is not None
+
+
+def test_edit_expense_missing_description(client, app):
+    """Test that editing expense without description fails."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with empty description
+    expense_data = MultiDict(
+        [
+            ("description", ""),  # Empty description
+            ("amount", "50.00"),
+            ("payer", "payer@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Description is required" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.description == "Lunch"  # Should not be changed
+
+
+def test_edit_expense_missing_payer(client, app):
+    """Test that editing expense without payer fails."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with empty payer
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "50.00"),
+            ("payer", ""),  # Empty payer
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Payer is required" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.payer == "payer@example.com"  # Should not be changed
+
+
+def test_edit_expense_invalid_amount_format(client, app):
+    """Test that editing expense with invalid amount format fails."""
+    # Arrange
+    from werkzeug.datastructures import MultiDict
+
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with invalid amount (non-numeric)
+    expense_data = MultiDict(
+        [
+            ("description", "Dinner"),
+            ("amount", "not_a_number"),  # Invalid amount
+            ("payer", "payer@example.com"),
+            ("split_type", "equal"),
+            ("participants", "payer@example.com"),
+            ("participants", "editor@example.com"),
+        ]
+    )
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit", data=expense_data, follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Please enter a valid amount" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.amount == 30.0  # Should not be changed
+
+
+def test_edit_expense_no_participants_equal_split(client, app):
+    """Test that editing expense with equal split but no participants fails."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with equal split but no participants selected
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "equal",
+            # No participants provided
+        },
+        follow_redirects=True,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Please select at least one participant" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.description == "Lunch"  # Should not be changed
+
+
+def test_edit_expense_invalid_custom_amount_format(client, app):
+    """Test that editing expense with invalid custom amount format fails."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with invalid custom amount (non-numeric)
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "custom",
+            "custom_amount_payer@example.com": "not_a_number",  # Invalid custom amount
+        },
+        follow_redirects=True,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Invalid amount" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.amount == 30.0  # Should not be changed
+
+
+def test_edit_expense_no_custom_split_amounts(client, app):
+    """Test that editing expense with custom split but no amounts fails."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    editor = User(email="editor@example.com")
+    db.session.add_all([payer, editor])
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.extend([payer, editor])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 15.0, "editor@example.com": 15.0}',
+        participants="payer@example.com, editor@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = editor.id
+        sess["user_email"] = editor.email
+
+    # Act - try to edit with custom split but no amounts specified
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "custom",
+            # No custom_amount_* fields provided
+        },
+        follow_redirects=True,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Please specify amounts for at least one participant" in response.data
+    expense = Expense.query.get(expense_id)
+    assert expense.description == "Lunch"  # Should not be changed
+
+
+def test_edit_expense_user_not_found_error(client, app):
+    """Test edit expense handles user not found error."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="payer@example.com")
+    db.session.add(payer)
+    db.session.commit()
+
+    group = Group(name="Test Group", created_by_id=payer.id)
+    group.members.append(payer)
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="payer@example.com",
+        group_id=group.id,
+        split_type="equal",
+        split_details='{"payer@example.com": 30.0}',
+        participants="payer@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    # Act - Delete user after session is set up to test the defensive check
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        # Simulate user being deleted (defensive check in function)
+        db.session.delete(payer)
+        db.session.flush()  # Don't commit yet, but flush to make it visible
+
+    # The login_required decorator will catch this, but we test the defensive check
+    response = client.post(
+        f"/groups/{group.id}/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "payer@example.com",
+            "split_type": "equal",
+            "participants": ["payer@example.com"],
+        },
+        follow_redirects=True,
+    )
+
+    # Assert - login_required decorator should redirect to login
+    assert response.status_code == 200
+
+
+def test_edit_expense_group_not_found_error(client, app):
+    """Test edit expense handles group not found error."""
+    # Arrange
+    from extensions import db
+    from models import Expense
+
+    user = User(email="user@example.com")
+    db.session.add(user)
+    db.session.commit()
+
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="user@example.com",
+        group_id=99999,  # Non-existent group
+        split_type="equal",
+        split_details='{"user@example.com": 30.0}',
+        participants="user@example.com",
+    )
+    db.session.add(expense)
+    db.session.commit()
+    expense_id = expense.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["user_email"] = user.email
+
+    # Act
+    response = client.post(
+        f"/groups/99999/expense/{expense_id}/edit",
+        data={
+            "description": "Dinner",
+            "amount": "50.00",
+            "payer": "user@example.com",
+            "split_type": "equal",
+            "participants": ["user@example.com"],
+        },
+        follow_redirects=True,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Group not found" in response.data


### PR DESCRIPTION
# Edit Expense Feature
Implements the ability to edit expenses within a group, allowing any group member to update expense details including description, amount, payer, split type, and participants. When an expense is edited, all group members receive a notification banner in the group tab.

**User Story:** As a college student, I want to edit the amount and participants of an expense after I've created it so that I can easily correct mistakes without having to delete and re-enter the entire expense.

## ✅ Acceptance Criteria Met

- ✅ Any member of the group can edit any expense (not restricted to creator)
- ✅ Users can update total amount, description, payer, split type, and participants
- ✅ Amount validation: negative numbers are rejected with error message
- ✅ All participant balances are automatically recalculated after edit
- ✅ Other group members receive notification banner when expense is edited
- ✅ Notification shows expense details and who edited it
- ✅ Users can dismiss notifications by clicking close button

## 📝 Key Changes

### Backend (`routes/groups.py`)
- **New Route:** `POST /groups/<group_id>/expense/<expense_id>/edit`
  - Validates user authentication and group membership
  - Validates expense belongs to the group
  - Validates form data (description, amount > 0, payer, participants, split)
  - Updates expense in database
  - Creates `GroupNotification` record for other group members
  - Sends terminal notifications via `notify_expense_edited`

### Backend (`models.py`)
- **Enhanced:** `GroupNotification` model
  - Added `edited_by` field to track who edited an expense
  - Supports `expense_edited` notification type alongside `expense_deleted`

### Backend (`services/notification_service.py`)
- **New Function:** `notify_expense_edited(expense, editor_email, group_members)`
  - Sends terminal notifications to all group members except the editor
  - Displays expense details and editor information

### Frontend (`templates/groups/expenses.html`)
- **UI Enhancement:** Inline edit form that expands when clicking "Edit" button
  - Edit button added next to Delete button on each expense card
  - Form pre-populates with current expense values
  - Supports both equal and custom split types
  - Real-time split calculations displayed
  - Cancel button to exit edit mode without saving
- **Notification Banner:** Edit notification banner similar to deletion banner
  - Blue theme (vs yellow for deletions)
  - Displays expense description, amount, payer, and editor name
  - Dismissible with close button that marks notification as read
- **JavaScript:** Added functions for:
  - `toggleEditMode(expenseId)` - Shows/hides edit form
  - `cancelEditMode(expenseId)` - Cancels editing
  - `populateEditForm(expenseId)` - Pre-populates form fields
  - `setupEditFormListeners(expenseId)` - Handles form interactions
  - `updateEditSplitCalculations(expenseId)` - Real-time split calculations
  
 ### Screenshots
 1. Edit Button:
<img width="1251" height="579" alt="Screenshot 2025-11-02 182244" src="https://github.com/user-attachments/assets/651b1565-e566-45d2-b602-c8b562b72832" />
2. Inline edit form:
<img width="816" height="508" alt="Screenshot 2025-11-02 182251" src="https://github.com/user-attachments/assets/ec46442c-1b59-4419-abec-e98c034e2ee5" />

## 🔄 Related Changes

- Removed balance calculation from groups page (now shows transaction count instead)
- Updated `group_expenses` GET handler to fetch and display edit notifications
- Existing `mark_notification_read` route handles both deletion and edit notifications

