### PR TITLE
View Detailed Balance Breakdown and Simplified Pay #13

### DIFF
--- a/routes/expenses.py
+++ b/routes/expenses.py
@@ -32,10 +32,18 @@ def balance_summary():
 
     # Calculate balances using the service
     balance_data = ExpenseService.calculate_balances(expenses)
+    
+    # Calculate detailed breakdown (all pairwise debts)
+    detailed_breakdown = ExpenseService.calculate_detailed_breakdown(expenses)
 
     # Create mapping of email to display name
     all_emails = set(balance_data["balances"].keys())
     for transaction in balance_data["transactions"]:
+        all_emails.add(transaction["from"])
+        all_emails.add(transaction["to"])
+    
+    # Also include emails from detailed breakdown
+    for transaction in detailed_breakdown:
         all_emails.add(transaction["from"])
         all_emails.add(transaction["to"])
 
@@ -66,6 +74,7 @@ def balance_summary():
         page_id="balance-summary",
         balances=balance_data["balances"],
         transactions=balance_data["transactions"],
+        detailed_breakdown=detailed_breakdown,
         email_to_name=email_to_name,
         groups=groups,
         groups_data=groups_data,

--- a/services/expense_service.py
+++ b/services/expense_service.py
@@ -62,6 +62,55 @@ class ExpenseService:
         return {"balances": balances, "transactions": transactions}
 
     @staticmethod
+    def calculate_detailed_breakdown(expenses):
+        """
+        Calculate detailed breakdown showing ALL pairwise debts from each expense.
+        
+        Unlike calculate_balances() which simplifies debts, this shows the actual
+        debts created by each expense (who owes the payer for their share).
+        
+        Args:
+            expenses: List of Expense model objects
+            
+        Returns:
+            List of detailed debt transactions in format:
+            [{
+                'from': person_who_owes,
+                'to': person_who_paid,
+                'amount': amount_owed,
+                'expense_description': 'Lunch',
+                'expense_id': 123
+            }, ...]
+        """
+        if not expenses:
+            return []
+        
+        detailed_transactions = []
+        
+        for expense in expenses:
+            payer = expense.payer
+            split_details = ExpenseService._parse_split_details(expense)
+            
+            if not split_details:
+                continue
+            
+            # For each participant (excluding payer), create a debt record
+            for participant, amount in split_details.items():
+                if participant != payer and amount > 0.01:  # Skip payer and zero amounts
+                    detailed_transactions.append({
+                        'from': participant,
+                        'to': payer,
+                        'amount': round(amount, 2),
+                        'expense_description': expense.description,
+                        'expense_id': expense.id
+                    })
+        
+        # Sort by amount (largest first) for better readability
+        detailed_transactions.sort(key=lambda x: x['amount'], reverse=True)
+        
+        return detailed_transactions
+
+    @staticmethod
     def _simplify_debts(balances):
         """
         Simplify debts into minimal transactions.

--- a/templates/apps/expense_splitter/balance.html
+++ b/templates/apps/expense_splitter/balance.html
@@ -27,7 +27,25 @@
     }
     .balance-neutral {
         background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
-        border-left: 4px solid #6b7280;
+        border-left: 4px solid #9ca3af;
+    }
+    .view-toggle-btn {
+        background: #f3f4f6;
+        color: #6b7280;
+        border: 2px solid transparent;
+    }
+    .view-toggle-btn:hover {
+        background: #e5e7eb;
+        color: #374151;
+    }
+    .view-toggle-btn.active {
+        background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+        color: white;
+        border-color: #6366f1;
+        box-shadow: 0 4px 6px -1px rgba(99, 102, 241, 0.3);
+    }
+    .view-container {
+        animation: fadeIn 0.3s ease-out;
     }
 </style>
 {% endblock %}
@@ -139,7 +157,24 @@
     {% endfor %}
 </div>
 
-<!-- Simplified Transactions -->
+<!-- View Toggle Buttons -->
+<div class="flex justify-center gap-4 mb-8">
+    <button id="btnSimplifiedView" onclick="showSimplifiedView()" class="view-toggle-btn active px-6 py-3 rounded-lg font-semibold transition-all duration-200 flex items-center gap-2">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+        </svg>
+        Simplified Pay
+    </button>
+    <button id="btnDetailedView" onclick="showDetailedView()" class="view-toggle-btn px-6 py-3 rounded-lg font-semibold transition-all duration-200 flex items-center gap-2">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
+        </svg>
+        Detailed Breakdown
+    </button>
+</div>
+
+<!-- Simplified Transactions (Existing) -->
+<div id="simplifiedView" class="view-container">
 {% if transactions %}
 <div class="bg-white rounded-xl shadow-lg p-8 border border-gray-200">
     <div class="flex items-center gap-3 mb-6">
@@ -148,7 +183,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
             </svg>
         </div>
-        <h3 class="text-2xl font-bold text-gray-900">Settlement Transactions</h3>
+        <h3 class="text-2xl font-bold text-gray-900">Simplified Pay</h3>
     </div>
     <p class="text-gray-600 mb-6">Follow these transactions to settle all debts with the minimum number of payments.</p>
     
@@ -200,6 +235,89 @@
     <p class="text-gray-600">Everyone's expenses are balanced. No transactions needed.</p>
 </div>
 {% endif %}
+</div>
+
+<!-- Detailed Breakdown View (New) -->
+<div id="detailedView" class="view-container" style="display: none;">
+{% if detailed_breakdown %}
+<div class="bg-white rounded-xl shadow-lg p-8 border border-gray-200">
+    <div class="flex items-center gap-3 mb-6">
+        <div class="p-2 bg-gradient-to-br from-indigo-500 to-blue-600 rounded-lg text-white">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
+            </svg>
+        </div>
+        <h3 class="text-2xl font-bold text-gray-900">Detailed Breakdown</h3>
+    </div>
+    <p class="text-gray-600 mb-6">See all individual debts from each expense. This shows the complete payment network before simplification.</p>
+    
+    <div class="space-y-3">
+        {% for transaction in detailed_breakdown %}
+        <div class="slide-in bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg p-4 border border-blue-200 hover:shadow-md transition-shadow duration-200">
+            <div class="flex items-center justify-between flex-wrap gap-3">
+                <div class="flex items-center gap-4 flex-1">
+                    <div class="flex items-center gap-2 font-semibold text-gray-900 min-w-[100px]">
+                        <svg class="w-4 h-4 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+                        </svg>
+                        <span class="text-sm">{{ email_to_name.get(transaction.from, transaction.from) }}</span>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+                        </svg>
+                        <span class="text-lg font-bold text-indigo-600">
+                            ${{ "%.2f"|format(transaction.amount) }}
+                        </span>
+                        <svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+                        </svg>
+                    </div>
+                    <div class="flex items-center gap-2 font-semibold text-gray-900 min-w-[100px]">
+                        <svg class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+                        </svg>
+                        <span class="text-sm">{{ email_to_name.get(transaction.to, transaction.to) }}</span>
+                    </div>
+                </div>
+                <div class="flex items-center gap-2 text-xs text-gray-600 bg-white px-3 py-1 rounded-full border border-gray-200">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
+                    </svg>
+                    {{ transaction.expense_description }}
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    
+    <div class="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <div class="flex items-start gap-2">
+            <svg class="w-5 h-5 text-blue-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+            <div class="text-sm text-blue-800">
+                <strong>Total debts:</strong> {{ detailed_breakdown|length }} transaction(s). Switch to "Simplified Pay" to see the optimized payment plan.
+            </div>
+        </div>
+    </div>
+</div>
+{% else %}
+<!-- All settled message -->
+<div class="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl p-8 text-center border border-green-200">
+    <div class="flex justify-center mb-4">
+        <div class="p-4 bg-green-100 rounded-full">
+            <svg class="w-12 h-12 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+        </div>
+    </div>
+    <h3 class="text-xl font-bold text-gray-900 mb-2">All Settled! 🎉</h3>
+    <p class="text-gray-600">Everyone's expenses are balanced. No transactions needed.</p>
+</div>
+{% endif %}
+</div>
+
 {% endif %}
 
 <div class="mt-8 text-center">
@@ -207,4 +325,26 @@
         Add More Expenses
     </a>
 </div>
+
+<script>
+    function showSimplifiedView() {
+        // Hide detailed, show simplified
+        document.getElementById('detailedView').style.display = 'none';
+        document.getElementById('simplifiedView').style.display = 'block';
+        
+        // Update button states
+        document.getElementById('btnSimplifiedView').classList.add('active');
+        document.getElementById('btnDetailedView').classList.remove('active');
+    }
+    
+    function showDetailedView() {
+        // Hide simplified, show detailed
+        document.getElementById('simplifiedView').style.display = 'none';
+        document.getElementById('detailedView').style.display = 'block';
+        
+        // Update button states
+        document.getElementById('btnDetailedView').classList.add('active');
+        document.getElementById('btnSimplifiedView').classList.remove('active');
+    }
+</script>
 {% endblock %}

--- a/tests/test_balance_routes.py
+++ b/tests/test_balance_routes.py
@@ -225,3 +225,91 @@ def test_balance_summary_handles_nonexistent_user_emails(client, app):
     # Should display email addresses as fallback when user not found (line 217 coverage)
     assert b"nonexistent@example.com" in response.data
     assert b"another@example.com" in response.data
+
+
+def test_balance_summary_includes_detailed_breakdown(client, app):
+    """Test that balance summary includes detailed breakdown data."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        user = User(email="test@example.com")
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+
+    with client.session_transaction() as session:
+        session["user_id"] = user_id
+        session["user_email"] = "test@example.com"
+
+    # Alice paid $30 for lunch split equally
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="Alice",
+        participants="Alice, Bob, Charlie",
+        split_type="equal",
+        split_details='{"Alice": 10.0, "Bob": 10.0, "Charlie": 10.0}',
+    )
+    db.session.add(expense)
+    db.session.commit()
+
+    # Act
+    response = client.get("/balance-summary")
+
+    # Assert
+    assert response.status_code == 200
+    # Should include detailed breakdown view elements
+    assert b"Detailed Breakdown" in response.data
+    assert b"Simplified Pay" in response.data
+    # Should show expense description in detailed view
+    assert b"Lunch" in response.data
+
+
+def test_balance_summary_detailed_breakdown_with_multiple_expenses(client, app):
+    """Test detailed breakdown shows all transactions from multiple expenses."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        user = User(email="test@example.com")
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+
+    with client.session_transaction() as session:
+        session["user_id"] = user_id
+        session["user_email"] = "test@example.com"
+
+    # Create two expenses
+    expense1 = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="Alice",
+        participants="Alice, Bob",
+        split_type="equal",
+        split_details='{"Alice": 15.0, "Bob": 15.0}',
+    )
+    expense2 = Expense(
+        description="Dinner",
+        amount=60.0,
+        payer="Bob",
+        participants="Alice, Bob",
+        split_type="equal",
+        split_details='{"Alice": 30.0, "Bob": 30.0}',
+    )
+    db.session.add_all([expense1, expense2])
+    db.session.commit()
+
+    # Act
+    response = client.get("/balance-summary")
+
+    # Assert
+    assert response.status_code == 200
+    # Both expense descriptions should appear in detailed breakdown
+    assert b"Lunch" in response.data
+    assert b"Dinner" in response.data
+    # Toggle buttons should be present
+    assert b"btnSimplifiedView" in response.data
+    assert b"btnDetailedView" in response.data
+

--- a/tests/test_expense_service.py
+++ b/tests/test_expense_service.py
@@ -279,3 +279,167 @@ def test_validate_shares_split_zero_shares(app):
     # Assert
     assert not is_valid
     assert "positive" in error_msg.lower()
+
+
+# === Detailed Breakdown Tests ===
+
+
+def test_calculate_detailed_breakdown_with_single_expense(app):
+    """Test detailed breakdown with one expense."""
+    from extensions import db
+    from services.expense_service import ExpenseService
+
+    # Arrange - Alice paid $30 for lunch split equally among Alice, Bob, Charlie
+    expense = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="alice@test.com",
+        split_type="equal",
+        split_details='{"alice@test.com": 10.0, "bob@test.com": 10.0, "charlie@test.com": 10.0}',
+    )
+    db.session.add(expense)
+    db.session.commit()
+
+    # Act
+    breakdown = ExpenseService.calculate_detailed_breakdown([expense])
+
+    # Assert
+    # Bob owes Alice $10, Charlie owes Alice $10 (Alice doesn't owe herself)
+    assert len(breakdown) == 2
+    assert {"from": "bob@test.com", "to": "alice@test.com", "amount": 10.0} in [
+        {k: v for k, v in t.items() if k in ["from", "to", "amount"]} for t in breakdown
+    ]
+    assert {"from": "charlie@test.com", "to": "alice@test.com", "amount": 10.0} in [
+        {k: v for k, v in t.items() if k in ["from", "to", "amount"]} for t in breakdown
+    ]
+    # Check expense description is included
+    assert all(t["expense_description"] == "Lunch" for t in breakdown)
+
+
+def test_calculate_detailed_breakdown_with_multiple_expenses(app):
+    """Test detailed breakdown with multiple expenses."""
+    from extensions import db
+    from services.expense_service import ExpenseService
+
+    # Arrange
+    expense1 = Expense(
+        description="Lunch",
+        amount=30.0,
+        payer="alice@test.com",
+        split_type="equal",
+        split_details='{"alice@test.com": 10.0, "bob@test.com": 10.0, "charlie@test.com": 10.0}',
+    )
+    expense2 = Expense(
+        description="Dinner",
+        amount=60.0,
+        payer="bob@test.com",
+        split_type="equal",
+        split_details='{"alice@test.com": 20.0, "bob@test.com": 20.0, "charlie@test.com": 20.0}',
+    )
+    db.session.add_all([expense1, expense2])
+    db.session.commit()
+
+    # Act
+    breakdown = ExpenseService.calculate_detailed_breakdown([expense1, expense2])
+
+    # Assert
+    # From expense1: Bob->Alice $10, Charlie->Alice $10
+    # From expense2: Alice->Bob $20, Charlie->Bob $20
+    # Total: 4 debt transactions
+    assert len(breakdown) == 4
+    
+    # Check all transactions exist
+    transactions = [
+        {k: v for k, v in t.items() if k in ["from", "to", "amount", "expense_description"]}
+        for t in breakdown
+    ]
+    assert {
+        "from": "bob@test.com",
+        "to": "alice@test.com",
+        "amount": 10.0,
+        "expense_description": "Lunch",
+    } in transactions
+    assert {
+        "from": "charlie@test.com",
+        "to": "alice@test.com",
+        "amount": 10.0,
+        "expense_description": "Lunch",
+    } in transactions
+    assert {
+        "from": "alice@test.com",
+        "to": "bob@test.com",
+        "amount": 20.0,
+        "expense_description": "Dinner",
+    } in transactions
+    assert {
+        "from": "charlie@test.com",
+        "to": "bob@test.com",
+        "amount": 20.0,
+        "expense_description": "Dinner",
+    } in transactions
+
+
+def test_calculate_detailed_breakdown_with_empty_expenses(app):
+    """Test detailed breakdown returns empty list for no expenses."""
+    from services.expense_service import ExpenseService
+
+    # Act
+    breakdown = ExpenseService.calculate_detailed_breakdown([])
+
+    # Assert
+    assert breakdown == []
+
+
+def test_calculate_detailed_breakdown_excludes_payer(app):
+    """Test that payer is not included in their own debt list."""
+    from extensions import db
+    from services.expense_service import ExpenseService
+
+    # Arrange
+    expense = Expense(
+        description="Coffee",
+        amount=15.0,
+        payer="alice@test.com",
+        split_type="equal",
+        split_details='{"alice@test.com": 5.0, "bob@test.com": 5.0, "charlie@test.com": 5.0}',
+    )
+    db.session.add(expense)
+    db.session.commit()
+
+    # Act
+    breakdown = ExpenseService.calculate_detailed_breakdown([expense])
+
+    # Assert
+    # Only Bob and Charlie owe Alice (Alice doesn't owe herself)
+    assert len(breakdown) == 2
+    assert not any(t["from"] == "alice@test.com" and t["to"] == "alice@test.com" for t in breakdown)
+
+
+def test_calculate_detailed_breakdown_with_percentage_split(app):
+    """Test detailed breakdown with percentage-based split."""
+    from extensions import db
+    from services.expense_service import ExpenseService
+
+    # Arrange - Alice paid $100, split 60% Bob, 40% Charlie
+    expense = Expense(
+        description="Groceries",
+        amount=100.0,
+        payer="alice@test.com",
+        split_type="percentage",
+        split_details='{"bob@test.com": 60.0, "charlie@test.com": 40.0}',
+    )
+    db.session.add(expense)
+    db.session.commit()
+
+    # Act
+    breakdown = ExpenseService.calculate_detailed_breakdown([expense])
+
+    # Assert
+    assert len(breakdown) == 2
+    assert {"from": "bob@test.com", "to": "alice@test.com", "amount": 60.0} in [
+        {k: v for k, v in t.items() if k in ["from", "to", "amount"]} for t in breakdown
+    ]
+    assert {"from": "charlie@test.com", "to": "alice@test.com", "amount": 40.0} in [
+        {k: v for k, v in t.items() if k in ["from", "to", "amount"]} for t in breakdown
+    ]
+


### PR DESCRIPTION
User Story
As a group member, I want to see who owes whom so that I understand the payment network within the group.

Acceptance Criteria
Given group expenses, when I tap "Detailed Breakdown" or "Simplified Pay", then relationships and amounts are shown clearly.
Definition of Done
Code merged via PR with review.
Tests passing in CI.
UI matches prototype.
Dependencies / Risks
Relies on up-to-date transaction records.

Changes:

✅ Acceptance Criteria Met:
✅ "Detailed Breakdown" - Shows ALL pairwise debts from each expense with expense descriptions
✅ "Simplified Pay" - Shows optimized payment plan with minimum transactions
✅ Toggle buttons to switch between views
✅ Relationships and amounts shown clearly with visual indicators
📊 Implementation Summary:
Files Modified:

expense_service.py - Added calculate_detailed_breakdown() method
expenses.py - Updated balance_summary() to provide both views
balance.html - Added toggle UI and detailed breakdown view

Issue

closes #13 

Screenshots

<img width="1298" height="467" alt="image" src="https://github.com/user-attachments/assets/8e65f22e-6e0d-4dc7-8325-d5b2ba5d9b34" />

<img width="1271" height="555" alt="image" src="https://github.com/user-attachments/assets/7105fd86-3f01-4d2e-843d-80450b6b256d" />

<img width="960" height="178" alt="image" src="https://github.com/user-attachments/assets/c690313a-7273-434a-911f-05773dbafae5" />
