### PR TITLE
feat: add leave group

### DIFF
--- a/routes/groups.py
+++ b/routes/groups.py
@@ -720,3 +720,42 @@ def mark_notification_read(group_id, notification_id):
         db.session.commit()
 
     return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+@groups_bp.route("/<int:group_id>/leave", methods=["POST"])
+@login_required
+def leave_group(group_id):
+    """Remove the current user from the group."""
+    user_id = session.get("user_id")
+    user = db.session.get(User, user_id)
+    if not user:
+        flash("User not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    # Load the group
+    group = db.session.get(Group, group_id)
+    if not group:
+        flash("Group not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    # Must be a member
+    if user not in group.members:
+        flash("You are not a member of this group", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Prevent the *creator* from leaving (optional – you can remove this block if you want to allow it)
+    if group.created_by_id == user.id:
+        flash("The group creator cannot leave the group.", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Remove the relationship
+    group.members.remove(user)
+
+    # If the group ends up with **zero** members, delete it (optional)
+    if len(group.members) == 0:
+        db.session.delete(group)
+        flash("You left the group and it was removed (no members left).", "info")
+    else:
+        flash(f"You have left the group “{group.name}”.", "success")
+
+    db.session.commit()
+    return redirect(url_for("groups.list_groups"))

--- a/templates/groups/expenses.html
+++ b/templates/groups/expenses.html
@@ -58,6 +58,22 @@
             <h2 class="text-3xl font-bold text-gray-900">{{ group.name }}</h2>
             <p class="text-gray-600">Group expenses and transactions</p>
         </div>
+        <!-- ==== LEAVE GROUP BUTTON ==== -->
+        <div class="ml-auto">
+           <form action="{{ url_for('groups.leave_group', group_id=group.id) }}" method="post"
+          onsubmit="return confirm('Are you sure you want to leave “{{ group.name }}”?');"
+          class="inline">
+        <button type="submit"
+                class="inline-flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg font-medium transition-colors text-sm">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M17 16l4-4m0 0l-4-4m4 4H7m4 4v1a3 3 0 01-3 3H5a3 3 0 01-3-3v-1m5-7V5a3 3 0 013-3h2a3 3 0 013 3v1"></path>
+            </svg>
+            Leave Group
+        </button>
+        </form>
+        </div>
+        <!-- ==== END LEAVE BUTTON ==== -->
     </div>
 </div>
 

--- a/tests/test_group_routes.py
+++ b/tests/test_group_routes.py
@@ -2938,3 +2938,241 @@ def test_edit_expense_group_not_found_error(client, app):
     # Assert
     assert response.status_code == 200
     assert b"Group not found" in response.data
+
+
+    #==== TEST LEAVE GROUP ====
+def test_leave_group_success(client, app):
+    """Test that a group member can successfully leave a group."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    leaver = User(email="leaver@example.com")
+    db.session.add_all([creator, leaver])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, leaver])
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = leaver.id
+        sess["user_email"] = leaver.email
+    # Act
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=False)
+    # Assert
+    assert response.status_code == 302
+    assert response.location.endswith("/groups/")
+    updated_group = db.session.get(Group, group.id)
+    assert leaver not in updated_group.members
+    assert creator in updated_group.members  # Creator stays
+    assert len(updated_group.members) == 1
+
+
+def test_leave_group_creator_cannot_leave(client, app):
+    """Test that the group creator cannot leave the group."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    member = User(email="member@example.com")
+    db.session.add_all([creator, member])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, member])
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+    # Act
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=True)
+    # Assert
+    assert response.status_code == 200
+    assert b"The group creator cannot leave the group." in response.data
+    updated_group = db.session.get(Group, group.id)
+    assert creator in updated_group.members
+    assert member in updated_group.members
+
+
+def test_leave_group_requires_login(client, app):
+    """Test that unauthenticated users cannot leave a group."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    member = User(email="member@example.com")
+    db.session.add_all([creator, member])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, member])
+    db.session.add(group)
+    db.session.commit()
+    # Act - no login session
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=False)
+    # Assert
+    assert response.status_code == 302
+    assert "/login" in response.location
+    updated_group = db.session.get(Group, group.id)
+    assert member in updated_group.members  # Still in group
+
+
+def test_leave_group_requires_membership(client, app):
+    """Test that non-members cannot leave a group."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    non_member = User(email="nonmember@example.com")
+    db.session.add_all([creator, non_member])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.append(creator)
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = non_member.id
+        sess["user_email"] = non_member.email
+    # Act
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=True)
+    # Assert
+    assert response.status_code == 200
+    assert b"You are not a member of this group" in response.data
+    updated_group = db.session.get(Group, group.id)
+    assert non_member not in updated_group.members
+    assert creator in updated_group.members
+
+
+def test_leave_group_not_found(client, app):
+    """Test leaving a non-existent group returns error."""
+    # Arrange
+    from extensions import db
+    user = User(email="user@example.com")
+    db.session.add(user)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["user_email"] = user.email
+    # Act
+    response = client.post("/groups/99999/leave", follow_redirects=True)
+    # Assert
+    assert response.status_code == 200
+    assert b"Group not found" in response.data
+
+
+def test_leave_group_redirects_to_groups_list(client, app):
+    """Test that after leaving, user is redirected to /groups/."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    leaver = User(email="leaver@example.com")
+    db.session.add_all([creator, leaver])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, leaver])
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = leaver.id
+        sess["user_email"] = leaver.email
+    # Act
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=False)
+    # Assert
+    assert response.status_code == 302
+    assert response.location.endswith("/groups/")
+
+
+def test_leave_group_shows_success_message(client, app):
+    """Test that a flash message confirms successful leave."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    leaver = User(email="leaver@example.com")
+    db.session.add_all([creator, leaver])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, leaver])
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = leaver.id
+        sess["user_email"] = leaver.email
+    # Act
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=True)
+    # Assert
+    assert response.status_code == 200
+    assert b"You have left the group" in response.data or b"left the group" in response.data.lower()
+
+
+def test_leave_group_removes_only_leaver(client, app):
+    """Test that only the leaving user is removed from the group."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    leaver = User(email="leaver@example.com")
+    other = User(email="other@example.com")
+    db.session.add_all([creator, leaver, other])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, leaver, other])
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = leaver.id
+        sess["user_email"] = leaver.email
+    # Act
+    client.post(f"/groups/{group.id}/leave")
+    # Assert
+    updated_group = db.session.get(Group, group.id)
+    assert leaver not in updated_group.members
+    assert creator in updated_group.members
+    assert other in updated_group.members
+    assert len(updated_group.members) == 2
+
+
+def test_leave_group_last_member_except_creator(client, app):
+    """Test that a group with only creator + one member allows leaving."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    leaver = User(email="leaver@example.com")
+    db.session.add_all([creator, leaver])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, leaver])
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = leaver.id
+        sess["user_email"] = leaver.email
+    # Act
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=False)
+    # Assert
+    assert response.status_code == 302
+    updated_group = db.session.get(Group, group.id)
+    assert leaver not in updated_group.members
+    assert creator in updated_group.members
+    assert len(updated_group.members) == 1  # Only creator remains
+
+
+def test_leave_group_user_not_found_defensive(client, app):
+    """Test defensive handling when user is deleted mid-session."""
+    # Arrange
+    from extensions import db
+    creator = User(email="creator@example.com")
+    leaver = User(email="leaver@example.com")
+    db.session.add_all([creator, leaver])
+    db.session.commit()
+    group = Group(name="Test Group", created_by_id=creator.id)
+    group.members.extend([creator, leaver])
+    db.session.add(group)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = leaver.id
+        sess["user_email"] = leaver.email
+        # Simulate user deletion
+        db.session.delete(leaver)
+        db.session.flush()
+    # Act
+    response = client.post(f"/groups/{group.id}/leave", follow_redirects=True)
+    # Assert - should redirect to login due to login_required
+    assert response.status_code == 200
+    # Group should still exist, leaver already gone
+    updated_group = db.session.get(Group, group.id)
+    assert creator in updated_group.members
+


### PR DESCRIPTION
📋 Description

Adds a Leave Group button in the group detail page. When clicked, if the logged in user is not the group creator, it removes self from the group's members.

🎯 Changes Made

Added functions for Leave Group.
Updated expenses.html to show the Leave Group button
Added tests for Leave Group functionality

🧪 Testing

All tests pass (uv run pytest -v)
Coverage meets requirements (most are 95%+ per file, 93% overall)
Updated existing tests to match new behavior

🔗 Related Story

Closes https://github.com/PradHolla/CS-555-A-Course-Project/issues/25

📸 Screenshots
Shows Leave button:
![WhatsApp Image 2025-11-04 at 09 41 50](https://github.com/user-attachments/assets/fcfd8f5f-c09a-495c-bd4a-53f30e88f2ff)

Asks for confirmation:
![WhatsApp Image 2025-11-04 at 09 42 37](https://github.com/user-attachments/assets/08e97d22-61bc-4373-90ba-f334c020648e)

Shows the Leave confirmation message:
![WhatsApp Image 2025-11-04 at 09 42 53](https://github.com/user-attachments/assets/e88905a3-f123-42a7-b38b-f1fb5c5f1133)

🔄 Files Changed
routes/groups.py - Added methods to leave the group
templates/groups/expenses.html - Added Leave button
test_group_routes.py - Added tests for Leave Group
