### PR TITLE
feat: add delete-current-group

### DIFF
--- a/routes/groups.py
+++ b/routes/groups.py
@@ -424,6 +424,7 @@ def group_expenses(group_id):
         deletion_info=deletion_info,
         edit_info=edit_info,
         transaction_count=transaction_count,
+        current_user_id=user_id,
     )
 
 
@@ -1022,4 +1023,59 @@ def leave_group(group_id):
         flash(f"You have left the group “{group.name}”.", "success")
 
     db.session.commit()
+    return redirect(url_for("groups.list_groups"))
+
+
+@groups_bp.route("/<int:group_id>/delete", methods=["POST"])
+@login_required
+def delete_group(group_id):
+    """Delete the group — only the creator may delete the group."""
+    user_id = session.get("user_id")
+    user = db.session.get(User, user_id)
+
+    if not user:
+        flash("User not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    group = db.session.get(Group, group_id)
+    if not group:
+        flash("Group not found", "error")
+        return redirect(url_for("groups.list_groups"))
+
+    # Verify membership
+    if user not in group.members:
+        flash("You are not a member of this group", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Only creator can delete
+    if group.created_by_id != user.id:
+        flash("Only the group creator can delete this group.", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    # Delete group and redirect to groups list
+    # Delete related child objects first to avoid FK NOT NULL issues (invitations, notifications, expenses)
+    # Invitations have group_id non-nullable so they must be removed before deleting the group.
+    try:
+        # Delete invitations
+        for inv in list(group.invitations):
+            db.session.delete(inv)
+
+        # Delete notifications
+        from models import GroupNotification, Expense
+
+        for note in list(group.notifications):
+            db.session.delete(note)
+
+        # Delete expenses (and their comments via cascade defined on Comment)
+        for exp in list(group.expenses):
+            db.session.delete(exp)
+
+        db.session.delete(group)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        flash("Failed to delete group due to related data constraints.", "error")
+        return redirect(url_for("groups.group_expenses", group_id=group_id))
+
+    flash(f"Group '{group.name}' deleted successfully.", "success")
     return redirect(url_for("groups.list_groups"))

--- a/templates/groups/expenses.html
+++ b/templates/groups/expenses.html
@@ -58,7 +58,7 @@
             <h2 class="text-3xl font-bold text-gray-900">{{ group.name }}</h2>
             <p class="text-gray-600">Group expenses and transactions</p>
         </div>
-        <!-- ==== LEAVE GROUP BUTTON ==== -->
+    <!-- ==== LEAVE GROUP BUTTON ==== -->
         <div class="ml-auto">
            <form action="{{ url_for('groups.leave_group', group_id=group.id) }}" method="post"
           onsubmit="return confirm('Are you sure you want to leave “{{ group.name }}”?');"
@@ -73,6 +73,23 @@
         </button>
         </form>
         </div>
+        <!-- ==== DELETE GROUP BUTTON (visible only to creator) ==== -->
+        {% if group.created_by_id == session.get('user_id') %}
+        <div class="ml-2 inline">
+           <form action="{{ url_for('groups.delete_group', group_id=group.id) }}" method="post"
+                 onsubmit="return confirm('Are you sure you want to permanently delete the group “{{ group.name }}”? This cannot be undone.');"
+                 class="inline">
+            <button type="submit"
+                    class="inline-flex items-center gap-2 bg-red-700 hover:bg-red-800 text-white px-4 py-2 rounded-lg font-medium transition-colors text-sm">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+                Delete Group
+            </button>
+           </form>
+        </div>
+        {% endif %}
         <!-- ==== END LEAVE BUTTON ==== -->
     </div>
 </div>

--- a/tests/test_group_delete.py
+++ b/tests/test_group_delete.py
@@ -1,0 +1,214 @@
+"""Tests for group deletion behaviour."""
+
+from models import Group, User
+
+
+def test_delete_group_by_creator_removes_children(client, app):
+    """Creator can delete a group and related invitations/notifications/expenses are removed."""
+    from extensions import db
+    from models import GroupInvitation, Expense, GroupNotification
+
+    # Arrange
+    creator = User(email="creator@example.com")
+    member = User(email="member@example.com")
+    db.session.add_all([creator, member])
+    db.session.commit()
+
+    group = Group(name="ToBeDeleted", created_by_id=creator.id)
+    group.members.extend([creator, member])
+    db.session.add(group)
+    db.session.commit()
+
+    # Add an invitation, expense and notification tied to the group
+    invitation = GroupInvitation(email="invitee@example.com", group_id=group.id, invited_by_id=creator.id)
+    expense = Expense(description="Lunch", amount=10.0, payer=creator.email, group_id=group.id, split_type="equal", split_details='{"creator@example.com": 10.0}', participants=creator.email)
+    notification = GroupNotification(group_id=group.id, notification_type="expense_deleted", description="Lunch", amount=10.0, payer=creator.email, deleted_by=creator.email, read_by="[]")
+    db.session.add_all([invitation, expense, notification])
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+
+    # Act
+    response = client.post(f"/groups/{group.id}/delete", follow_redirects=False)
+
+    # Assert - redirect to groups list and group and children removed
+    assert response.status_code == 302
+    assert db.session.get(Group, group.id) is None
+    assert GroupInvitation.query.filter_by(group_id=group.id).first() is None
+    assert Expense.query.filter_by(group_id=group.id).first() is None
+    assert GroupNotification.query.filter_by(group_id=group.id).first() is None
+
+
+def test_delete_group_non_creator_cannot_delete(client, app):
+    """A non-creator (even a member) cannot delete the group."""
+    from extensions import db
+
+    creator = User(email="creator2@example.com")
+    other = User(email="other@example.com")
+    db.session.add_all([creator, other])
+    db.session.commit()
+
+    group = Group(name="SafeGroup", created_by_id=creator.id)
+    group.members.extend([creator, other])
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = other.id
+        sess["user_email"] = other.email
+
+    # Act
+    response = client.post(f"/groups/{group.id}/delete", follow_redirects=False)
+
+    # Assert - should not delete and should redirect back to group page
+    assert response.status_code == 302
+    assert db.session.get(Group, group.id) is not None
+
+
+def test_delete_button_visibility(client, app):
+    """Only the creator sees the Delete Group button on the group page."""
+    from extensions import db
+
+    creator = User(email="creator3@example.com")
+    member = User(email="member3@example.com")
+    db.session.add_all([creator, member])
+    db.session.commit()
+
+    group = Group(name="VisibleGroup", created_by_id=creator.id)
+    group.members.extend([creator, member])
+    db.session.add(group)
+    db.session.commit()
+
+    # As creator - should see button
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+    response = client.get(f"/groups/{group.id}")
+    assert response.status_code == 200
+    assert b"Delete Group" in response.data
+
+    # As normal member - should NOT see button
+    with client.session_transaction() as sess:
+        sess["user_id"] = member.id
+        sess["user_email"] = member.email
+    response = client.get(f"/groups/{group.id}")
+    assert response.status_code == 200
+    assert b"Delete Group" not in response.data
+
+
+def test_delete_group_handles_commit_failure(client, app, monkeypatch):
+    """If commit fails during deletion, the group remains and an error is flashed."""
+    from extensions import db
+
+    creator = User(email="errcreator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    group = Group(name="ErrGroup", created_by_id=creator.id)
+    group.members.append(creator)
+    db.session.add(group)
+    db.session.commit()
+
+    # Monkeypatch commit to raise only during delete
+    real_commit = db.session.commit
+
+    def fake_commit():
+        raise Exception("boom")
+
+    monkeypatch.setattr(db.session, "commit", fake_commit)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+
+    response = client.post(f"/groups/{group.id}/delete", follow_redirects=True)
+
+    # After failure, group should still exist
+    assert response.status_code == 200
+    assert b"Failed to delete group" in response.data or b"Failed to delete group due to related data constraints" in response.data
+    assert db.session.get(Group, group.id) is not None
+
+    # restore commit to avoid breaking other tests
+    monkeypatch.setattr(db.session, "commit", real_commit)
+
+
+def test_create_group_adds_existing_and_invites_others(client, app):
+    """Creating a group with a mix of existing users and unknown emails should add existing users and create invitations."""
+    from extensions import db
+    from models import GroupInvitation
+
+    creator = User(email="creator4@example.com")
+    existing = User(email="existing@example.com")
+    db.session.add_all([creator, existing])
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+
+    data = {
+        "name": "MixedGroup",
+        "members": f"{existing.email}, newinvite@example.com",
+    }
+
+    response = client.post("/groups/create", data=data, follow_redirects=False)
+    assert response.status_code == 302
+
+    group = Group.query.filter_by(name="MixedGroup").first()
+    assert group is not None
+    # existing user should be a member
+    assert any(m.email == existing.email for m in group.members)
+    # newinvite should have an invitation
+    assert GroupInvitation.query.filter_by(email="newinvite@example.com", group_id=group.id).first() is not None
+
+
+def test_group_expenses_create_percentage_and_shares(client, app):
+    """POST to group expenses with percentage and shares splits should create expenses."""
+    from extensions import db
+    from models import Expense
+
+    payer = User(email="p_percent@example.com")
+    p2 = User(email="p2_percent@example.com")
+    db.session.add_all([payer, p2])
+    db.session.commit()
+
+    group = Group(name="SplitGroup", created_by_id=payer.id)
+    group.members.extend([payer, p2])
+    db.session.add(group)
+    db.session.commit()
+
+    # Percentage split
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    percent_data = {
+        "description": "Pct Lunch",
+        "amount": "100.00",
+        "payer": payer.email,
+        "split_type": "percentage",
+        f"percentage_{payer.email}": "60",
+        f"percentage_{p2.email}": "40",
+    }
+
+    response = client.post(f"/groups/{group.id}", data=percent_data, follow_redirects=False)
+    assert response.status_code == 302
+    expense = Expense.query.filter_by(description="Pct Lunch", group_id=group.id).first()
+    assert expense is not None
+
+    # Shares split
+    shares_data = {
+        "description": "Shares Dinner",
+        "amount": "90.00",
+        "payer": payer.email,
+        "split_type": "shares",
+        f"shares_{payer.email}": "2",
+        f"shares_{p2.email}": "1",
+    }
+
+    response = client.post(f"/groups/{group.id}", data=shares_data, follow_redirects=False)
+    assert response.status_code == 302
+    expense2 = Expense.query.filter_by(description="Shares Dinner", group_id=group.id).first()
+    assert expense2 is not None

--- a/tests/test_group_delete_more.py
+++ b/tests/test_group_delete_more.py
@@ -1,0 +1,142 @@
+"""Additional tests to raise coverage for group routes."""
+
+from models import Group, User
+
+
+def test_delete_group_non_member_blocked(client, app):
+    """Ensure a non-member cannot delete a group."""
+    from extensions import db
+
+    creator = User(email="c_nonmember@example.com")
+    outsider = User(email="outsider@example.com")
+    db.session.add_all([creator, outsider])
+    db.session.commit()
+
+    group = Group(name="NoDeleteGroup", created_by_id=creator.id)
+    group.members.append(creator)
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = outsider.id
+        sess["user_email"] = outsider.email
+
+    resp = client.post(f"/groups/{group.id}/delete", follow_redirects=True)
+    # Should not delete
+    assert db.session.get(Group, group.id) is not None
+    assert resp.status_code == 200 or resp.status_code == 302
+
+
+def test_delete_group_not_found_shows_error(client, app):
+    """Posting delete for non-existent group should flash Group not found."""
+    from extensions import db
+
+    user = User(email="u_notfound@example.com")
+    db.session.add(user)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["user_email"] = user.email
+
+    resp = client.post("/groups/999999/delete", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group not found" in resp.data
+
+
+def test_delete_group_user_missing_defensive(client, app):
+    """If the logged-in user is removed from DB mid-session, the delete should be handled gracefully."""
+    from extensions import db
+
+    creator = User(email="u_goner@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    group = Group(name="GonerGroup", created_by_id=creator.id)
+    group.members.append(creator)
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+        # simulate deletion mid-session
+        db.session.delete(creator)
+        db.session.flush()
+
+    resp = client.post(f"/groups/{group.id}/delete", follow_redirects=True)
+    # login_required or defensive checks should redirect to login (200 page)
+    assert resp.status_code == 200
+
+
+def test_create_expense_notification_failure_continues(client, app, monkeypatch):
+    """If notify_expense_participants raises, expense creation still succeeds."""
+    from extensions import db
+    from services.notification_service import notify_expense_participants
+    from models import Expense
+
+    payer = User(email="notif_fail_payer@example.com")
+    other = User(email="notif_fail_other@example.com")
+    db.session.add_all([payer, other])
+    db.session.commit()
+
+    group = Group(name="NotifFailGroup", created_by_id=payer.id)
+    group.members.extend([payer, other])
+    db.session.add(group)
+    db.session.commit()
+
+    # patch notification to raise
+    def fake_notify(expense, participants):
+        raise Exception("notify failed")
+
+    monkeypatch.setattr('services.notification_service.notify_expense_participants', fake_notify)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    data = {
+        "description": "BrokenNotify",
+        "amount": "20.00",
+        "payer": payer.email,
+        "split_type": "equal",
+        "participants": payer.email,
+        "participants": other.email,
+    }
+
+    resp = client.post(f"/groups/{group.id}", data=data, follow_redirects=False)
+    assert resp.status_code == 302
+    expense = Expense.query.filter_by(description="BrokenNotify", group_id=group.id).first()
+    assert expense is not None
+
+
+def test_group_expenses_custom_split_validation(client, app):
+    """Creating an expense with custom split that doesn't sum to total should be rejected."""
+    from extensions import db
+
+    payer = User(email="custom_payer@example.com")
+    p2 = User(email="custom_p2@example.com")
+    db.session.add_all([payer, p2])
+    db.session.commit()
+
+    group = Group(name="CustomGroup", created_by_id=payer.id)
+    group.members.extend([payer, p2])
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    data = {
+        "description": "Custom Expense",
+        "amount": "50.00",
+        "payer": payer.email,
+        "split_type": "custom",
+        f"custom_amount_{payer.email}": "10.00",
+        f"custom_amount_{p2.email}": "10.00",  # total 20 != 50
+    }
+
+    resp = client.post(f"/groups/{group.id}", data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"must equal total amount" in resp.data or b"must equal the total amount" in resp.data

--- a/tests/test_groups_more.py
+++ b/tests/test_groups_more.py
@@ -1,0 +1,207 @@
+"""Additional tests to increase coverage for routes/groups.py.
+
+These tests exercise leave_group, notifications read, expense deletion/edit flows,
+comment CRUD and custom-split validation branches.
+"""
+
+from extensions import db
+from models import User, Group, Expense, GroupNotification, Comment
+
+
+def test_leave_group_creator_cannot_leave(client, app):
+    creator = User(email="leave_creator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    group = Group(name="LeaveGroup", created_by_id=creator.id)
+    group.members.append(creator)
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+
+    resp = client.post(f"/groups/{group.id}/leave", follow_redirects=True)
+    assert resp.status_code == 200
+    # The route flashes a message that the creator cannot leave
+    assert b"The group creator cannot leave the group" in resp.data
+    assert db.session.get(Group, group.id) is not None
+
+
+def test_mark_notification_read_marks_user(client, app):
+    # Create creator + member and a notification
+    creator = User(email="n_creator@example.com")
+    member = User(email="n_member@example.com")
+    db.session.add_all([creator, member])
+    db.session.commit()
+
+    group = Group(name="NotifyGroup", created_by_id=creator.id)
+    group.members.extend([creator, member])
+    db.session.add(group)
+    db.session.commit()
+
+    note = GroupNotification(group_id=group.id, notification_type="expense_deleted", description="x", read_by="[]")
+    db.session.add(note)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = member.id
+        sess["user_email"] = member.email
+
+    resp = client.post(f"/groups/{group.id}/notification/{note.id}/read", follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+
+    # reload and check read_by contains member.id
+    refreshed = db.session.get(GroupNotification, note.id)
+    import json
+
+    read_by = json.loads(refreshed.read_by)
+    assert member.id in read_by
+
+
+def test_delete_expense_creates_notification_and_removes_expense(client, app):
+    creator = User(email="d_creator@example.com")
+    member = User(email="d_member@example.com")
+    db.session.add_all([creator, member])
+    db.session.commit()
+
+    group = Group(name="DGroup", created_by_id=creator.id)
+    group.members.extend([creator, member])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(description="ToDelete", amount=5.0, payer=creator.email, group_id=group.id, split_type="equal", split_details='{"d_creator@example.com":5.0}', participants=creator.email)
+    db.session.add(expense)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+
+    resp = client.post(f"/groups/{group.id}/expense/{expense.id}/delete", follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+
+    # expense removed
+    assert db.session.get(Expense, expense.id) is None
+
+    # a GroupNotification should have been created
+    gn = GroupNotification.query.filter_by(group_id=group.id, notification_type="expense_deleted").first()
+    assert gn is not None
+
+
+def test_comment_crud(client, app):
+    creator = User(email="c_creator@example.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    group = Group(name="CGroup", created_by_id=creator.id)
+    group.members.append(creator)
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(description="CExpense", amount=7.0, payer=creator.email, group_id=group.id, split_type="equal", split_details='{"c_creator@example.com":7.0}', participants=creator.email)
+    db.session.add(expense)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = creator.id
+        sess["user_email"] = creator.email
+
+    # create comment
+    resp = client.post(f"/groups/{group.id}/expense/{expense.id}/comment", data={"content": "Nice"}, follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+    comment = Comment.query.filter_by(expense_id=expense.id).first()
+    assert comment is not None
+
+    # edit comment
+    resp = client.post(f"/groups/{group.id}/expense/{expense.id}/comment/{comment.id}/edit", data={"content": "Updated"}, follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+    refreshed = db.session.get(Comment, comment.id)
+    assert refreshed.content == "Updated"
+
+    # delete comment
+    resp = client.post(f"/groups/{group.id}/expense/{expense.id}/comment/{comment.id}/delete", follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+    assert db.session.get(Comment, comment.id) is None
+
+
+def test_edit_expense_creates_notification_and_updates(client, app):
+    payer = User(email="e_payer@example.com")
+    p2 = User(email="e_p2@example.com")
+    db.session.add_all([payer, p2])
+    db.session.commit()
+
+    group = Group(name="EGroup", created_by_id=payer.id)
+    group.members.extend([payer, p2])
+    db.session.add(group)
+    db.session.commit()
+
+    expense = Expense(description="Old", amount=20.0, payer=payer.email, group_id=group.id, split_type="equal", split_details='{"e_payer@example.com":20.0}', participants=payer.email)
+    db.session.add(expense)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    data = {
+        "description": "NewDesc",
+        "amount": "30.00",
+        "payer": payer.email,
+        "split_type": "equal",
+        # send participants as list
+        "participants": [payer.email, p2.email],
+    }
+
+    resp = client.post(f"/groups/{group.id}/expense/{expense.id}/edit", data=data, follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+
+    updated = db.session.get(Expense, expense.id)
+    assert updated.description == "NewDesc"
+
+    gn = GroupNotification.query.filter_by(group_id=group.id, notification_type="expense_edited").first()
+    assert gn is not None
+
+
+def test_group_expenses_custom_split_validation(client, app):
+    payer = User(email="cust_payer@example.com")
+    p2 = User(email="cust_p2@example.com")
+    db.session.add_all([payer, p2])
+    db.session.commit()
+
+    group = Group(name="CustGroup", created_by_id=payer.id)
+    group.members.extend([payer, p2])
+    db.session.add(group)
+    db.session.commit()
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = payer.id
+        sess["user_email"] = payer.email
+
+    # invalid custom amounts (non-numeric)
+    bad_data = {
+        "description": "BadCustom",
+        "amount": "50",
+        "payer": payer.email,
+        "split_type": "custom",
+        f"custom_amount_{payer.email}": "abc",
+    }
+    resp = client.post(f"/groups/{group.id}", data=bad_data, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Invalid amount" in resp.data or b"Please specify amounts for at least one participant" in resp.data
+
+    # valid custom split
+    good_data = {
+        "description": "GoodCustom",
+        "amount": "100",
+        "payer": payer.email,
+        "split_type": "custom",
+        f"custom_amount_{payer.email}": "60",
+        f"custom_amount_{p2.email}": "40",
+    }
+
+    resp = client.post(f"/groups/{group.id}", data=good_data, follow_redirects=False)
+    assert resp.status_code in (302, 303, 307)
+    exp = Expense.query.filter_by(description="GoodCustom", group_id=group.id).first()
+    assert exp is not None


### PR DESCRIPTION
📋 Description
Added a Delete Group button in the group details page. When clicked, that particular group is deleted and this action can be executed only by the admin/creator.

🎯 Changes Made
Added functions for Delete Group. Updated expenses.html to show the Delete Group button . Added tests for Delete Group functionality

🧪 Testing
All tests pass (uv run pytest -v) 
Coverage meets requirements (91% overall)  groups.py - 86% 
Updated existing tests to match new behavior

🔗 Related Story
Closes https://github.com/PradHolla/CS-555-A-Course-Project/issues/24

Screenshots:
Showing delete button:
<img width="911" height="659" alt="Screenshot 2025-11-08 at 2 03 16 AM" src="https://github.com/user-attachments/assets/e619ec9a-e554-41f0-a72b-184438cd54b6" />

Showing confirmation of deletion:
<img width="592" height="238" alt="Screenshot 2025-11-08 at 2 03 46 AM" src="https://github.com/user-attachments/assets/a8f5c020-7a12-4a4a-8bd9-e40c1e0b5acf" />


🔄 Files Changed
routes/groups.py - Added function to delete a group
templates/groups/expenses.html - Added UI changes to add a Delete Group button
tests/test_group_routes.py - Added tests to test the functionality