### PR TITLE
feat: Implement invitation management routes and templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,11 +55,13 @@ def create_app():
 
     from routes.dashboard import dashboard_bp
     from routes.groups import groups_bp
+    from routes.invitations import invitations_bp
     from routes.profile import profile_bp
 
     app.register_blueprint(groups_bp)
     app.register_blueprint(profile_bp)
     app.register_blueprint(dashboard_bp)
+    app.register_blueprint(invitations_bp)
 
     return app
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -7,7 +7,7 @@ from flask import Blueprint, redirect, render_template, request, session, url_fo
 from flask_mail import Message
 
 from extensions import db, mail
-from models import GroupInvitation, User
+from models import User
 from services.auth_service import AuthService
 from utils.validators import is_valid_email
 
@@ -122,16 +122,6 @@ def verify_otp():
     # Clear OTP after successful verification
     user.otp = None
     user.otp_expiry = None
-
-    # Auto-accept any pending group invitations for this email
-    pending_invitations = GroupInvitation.query.filter_by(email=user.email, status="pending").all()
-    for invitation in pending_invitations:
-        # Add user to the group
-        if user not in invitation.group.members:
-            invitation.group.members.append(user)
-        # Mark invitation as accepted
-        invitation.status = "accepted"
-
     db.session.commit()
 
     # Create session

--- a/routes/groups.py
+++ b/routes/groups.py
@@ -86,31 +86,23 @@ def create_group():
                 if email == creator.email:
                     continue  # Skip creator (already added)
 
-                # Find existing user
-                user = User.query.filter_by(email=email).first()
+                # Check if invitation already exists (whether user exists or not)
+                existing_invitation = GroupInvitation.query.filter_by(
+                    email=email, group_id=group.id, status="pending"
+                ).first()
 
-                if user:
-                    # User exists - add them to the group
-                    if user not in group.members:
-                        group.members.append(user)
-                else:
-                    # User doesn't exist - create invitation
-                    # Check if invitation already exists
-                    existing_invitation = GroupInvitation.query.filter_by(
-                        email=email, group_id=group.id, status="pending"
-                    ).first()
+                if not existing_invitation:
+                    # Create invitation for all users (existing or not)
+                    invitation = GroupInvitation(
+                        email=email, group_id=group.id, invited_by_id=user_id
+                    )
+                    db.session.add(invitation)
 
-                    if not existing_invitation:
-                        invitation = GroupInvitation(
-                            email=email, group_id=group.id, invited_by_id=user_id
-                        )
-                        db.session.add(invitation)
-
-                        # Send invitation notification
-                        try:
-                            notify_group_invitation(creator.email, email, name)
-                        except Exception as e:
-                            print(f"Failed to send invitation notification: {e}")
+                    # Send invitation notification
+                    try:
+                        notify_group_invitation(creator.email, email, name)
+                    except Exception as e:
+                        print(f"Failed to send invitation notification: {e}")
 
         db.session.commit()
         flash(f"Group '{name}' created successfully!", "success")

--- a/routes/invitations.py
+++ b/routes/invitations.py
@@ -1,0 +1,116 @@
+"""Invitation management routes."""
+
+from flask import Blueprint, flash, redirect, render_template, session, url_for
+
+from extensions import db
+from models import GroupInvitation, User
+from utils.decorators import login_required
+
+invitations_bp = Blueprint("invitations", __name__, url_prefix="/invitations")
+
+
+@invitations_bp.route("/")
+@login_required
+def list_invitations():
+    """Display all pending invitations for the current user."""
+    user_id = session.get("user_id")
+    user = db.session.get(User, user_id)
+
+    if not user:
+        flash("User not found", "error")
+        return redirect(url_for("home.index"))
+
+    # Get pending invitations for this user's email
+    pending_invitations = (
+        GroupInvitation.query.filter_by(email=user.email, status="pending")
+        .order_by(GroupInvitation.created_at.desc())
+        .all()
+    )
+
+    return render_template("invitations/index.html", invitations=pending_invitations)
+
+
+@invitations_bp.route("/<int:invitation_id>/accept", methods=["POST"])
+@login_required
+def accept_invitation(invitation_id):
+    """Accept a group invitation."""
+    user_id = session.get("user_id")
+    user = db.session.get(User, user_id)
+
+    if not user:
+        flash("User not found", "error")
+        return redirect(url_for("invitations.list_invitations"))
+
+    # Get the invitation
+    invitation = db.session.get(GroupInvitation, invitation_id)
+
+    if not invitation:
+        flash("Invitation not found", "error")
+        return redirect(url_for("invitations.list_invitations"))
+
+    # Verify the invitation is for this user
+    if invitation.email != user.email:
+        flash("You are not authorized to accept this invitation", "error")
+        return redirect(url_for("invitations.list_invitations"))
+
+    # Verify invitation is still pending
+    if invitation.status != "pending":
+        flash("This invitation has already been processed", "info")
+        return redirect(url_for("invitations.list_invitations"))
+
+    try:
+        # Add user to the group
+        if user not in invitation.group.members:
+            invitation.group.members.append(user)
+
+        # Mark invitation as accepted
+        invitation.status = "accepted"
+
+        db.session.commit()
+        flash(f"Successfully joined '{invitation.group.name}'!", "success")
+    except Exception as e:
+        db.session.rollback()
+        flash(f"Failed to accept invitation: {str(e)}", "error")
+
+    return redirect(url_for("invitations.list_invitations"))
+
+
+@invitations_bp.route("/<int:invitation_id>/decline", methods=["POST"])
+@login_required
+def decline_invitation(invitation_id):
+    """Decline a group invitation."""
+    user_id = session.get("user_id")
+    user = db.session.get(User, user_id)
+
+    if not user:
+        flash("User not found", "error")
+        return redirect(url_for("invitations.list_invitations"))
+
+    # Get the invitation
+    invitation = db.session.get(GroupInvitation, invitation_id)
+
+    if not invitation:
+        flash("Invitation not found", "error")
+        return redirect(url_for("invitations.list_invitations"))
+
+    # Verify the invitation is for this user
+    if invitation.email != user.email:
+        flash("You are not authorized to decline this invitation", "error")
+        return redirect(url_for("invitations.list_invitations"))
+
+    # Verify invitation is still pending
+    if invitation.status != "pending":
+        flash("This invitation has already been processed", "info")
+        return redirect(url_for("invitations.list_invitations"))
+
+    try:
+        # Mark invitation as declined
+        invitation.status = "declined"
+
+        db.session.commit()
+        flash(f"Declined invitation to '{invitation.group.name}'", "info")
+    except Exception as e:
+        db.session.rollback()
+        flash(f"Failed to decline invitation: {str(e)}", "error")
+
+    return redirect(url_for("invitations.list_invitations"))

--- a/templates/base.html
+++ b/templates/base.html
@@ -41,6 +41,16 @@
                         </span>
                     </a>
                     {% if session.get('user_email') %}
+                    <a href="{{ url_for('invitations.list_invitations') }}" class="px-4 py-2 rounded-lg text-gray-600 hover:text-gray-900 hover:bg-gradient-to-r hover:from-purple-50 hover:to-pink-50 transition-all duration-200">
+                        <span class="flex items-center gap-2">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"></path>
+                            </svg>
+                            Invitations
+                        </span>
+                    </a>
+                    {% endif %}
+                    {% if session.get('user_email') %}
                     <div class="flex items-center gap-3 ml-4 pl-4 border-l border-gray-200">
                         <a href="{{ url_for('profile.view_profile') }}" class="px-4 py-2 rounded-lg text-gray-600 hover:text-gray-900 hover:bg-gradient-to-r hover:from-purple-50 hover:to-pink-50 transition-all duration-200">
                             <span class="flex items-center gap-2">
@@ -72,6 +82,9 @@
                 <a href="{{ url_for('dashboard.index') }}" class="block px-3 py-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-50">Dashboard</a>
                 {% endif %}
                 <a href="{{ url_for('groups.list_groups') }}" class="block px-3 py-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-50">Groups</a>
+                {% if session.get('user_email') %}
+                <a href="{{ url_for('invitations.list_invitations') }}" class="block px-3 py-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-50">Invitations</a>
+                {% endif %}
             </div>
         </div>
     </nav>

--- a/templates/invitations/index.html
+++ b/templates/invitations/index.html
@@ -1,0 +1,120 @@
+{% extends "base.html" %}
+
+{% block title %}Invitations • TeamSync{% endblock %}
+
+{% block content %}
+<div class="mb-8">
+    <div class="flex items-center gap-3 mb-6">
+        <div class="p-2.5 bg-gradient-to-br from-purple-500 to-pink-600 rounded-lg text-white">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"></path>
+            </svg>
+        </div>
+        <div>
+            <h1 class="text-3xl font-bold text-gray-900 mb-1">Group Invitations</h1>
+            <p class="text-gray-500">Accept or decline your pending group invitations</p>
+        </div>
+    </div>
+</div>
+
+<!-- Flash Messages -->
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <div class="mb-6 space-y-2">
+            {% for category, message in messages %}
+                <div class="p-3 rounded-lg {% if category == 'error' %}bg-red-50 text-red-700 border border-red-100{% elif category == 'success' %}bg-emerald-50 text-emerald-700 border border-emerald-100{% else %}bg-blue-50 text-blue-700 border border-blue-100{% endif %}">
+                    <div class="flex items-center gap-2">
+                        {% if category == 'error' %}
+                            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                        {% elif category == 'success' %}
+                            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                        {% endif %}
+                        <span class="text-sm">{{ message }}</span>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endwith %}
+
+<div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+    {% if invitations %}
+        <div class="divide-y divide-gray-100">
+            {% for invitation in invitations %}
+            <div class="p-5 hover:bg-purple-50/30 transition-colors">
+                <div class="flex items-start justify-between gap-4">
+                    <div class="flex items-start gap-3 flex-1">
+                        <div class="p-2 bg-gradient-to-br from-purple-500 to-pink-600 rounded-lg text-white flex-shrink-0 mt-0.5">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                            </svg>
+                        </div>
+                        <div class="flex-1">
+                            <h3 class="text-lg font-semibold text-gray-900 mb-2">{{ invitation.group.name }}</h3>
+                            <div class="flex items-center gap-4 text-sm text-gray-500 mb-3">
+                                <div class="flex items-center gap-1.5">
+                                    <svg class="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+                                    </svg>
+                                    <span>Invited by <strong>{{ invitation.invited_by.display_name or invitation.invited_by.email }}</strong></span>
+                                </div>
+                                <div class="flex items-center gap-1.5">
+                                    <svg class="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                    </svg>
+                                    <span>{{ invitation.created_at.strftime('%b %d, %Y') }}</span>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-2 text-sm text-gray-600 mb-3">
+                                <svg class="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                                </svg>
+                                <span>{{ invitation.group.members|length }} member{{ 's' if invitation.group.members|length != 1 else '' }} in this group</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex gap-2">
+                        <form method="POST" action="{{ url_for('invitations.accept_invitation', invitation_id=invitation.id) }}" class="inline">
+                            <button type="submit" class="inline-flex items-center gap-1.5 bg-emerald-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-emerald-700 transition-colors">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                </svg>
+                                Accept
+                            </button>
+                        </form>
+                        <form method="POST" action="{{ url_for('invitations.decline_invitation', invitation_id=invitation.id) }}" class="inline">
+                            <button type="submit" class="inline-flex items-center gap-1.5 bg-gray-200 text-gray-700 px-4 py-2 rounded-lg font-medium hover:bg-gray-300 transition-colors">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                </svg>
+                                Decline
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="p-16 text-center">
+            <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-purple-100 mb-4">
+                <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"></path>
+                </svg>
+            </div>
+            <h3 class="text-lg font-medium text-gray-900 mb-2">No pending invitations</h3>
+            <p class="text-gray-500 mb-6">You don't have any group invitations at the moment</p>
+            <a href="{{ url_for('groups.list_groups') }}" class="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 font-medium">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+                </svg>
+                Back to Groups
+            </a>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def app(tmp_path):
         # Email configuration for testing - records emails without sending
         MAIL_SUPPRESS_SEND=True,  # Don't actually send emails in tests
         MAIL_DEFAULT_SENDER="test@sprintpay.local",
+        EMAIL_ENABLED=False,  # Always use detailed notification logging in tests
     )
 
     with flask_app.app_context():

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -159,8 +159,11 @@ def test_logout_clears_session(client, app):
         assert "user_email" not in sess
 
 
-def test_verify_otp_auto_accepts_pending_invitations(client, app):
-    """Test that verifying OTP auto-accepts pending group invitations."""
+def test_verify_otp_does_not_auto_accept_pending_invitations(client, app):
+    """Test that verifying OTP does NOT auto-accept pending group invitations.
+    
+    Users must manually accept invitations via the /invitations page.
+    """
     # Arrange
     from datetime import datetime, timedelta, timezone
 
@@ -199,10 +202,10 @@ def test_verify_otp_auto_accepts_pending_invitations(client, app):
     # Assert
     assert response.status_code == 302
 
-    # Check user was added to group
+    # Check user was NOT automatically added to group
     db.session.refresh(group)
-    assert new_user in group.members
+    assert new_user not in group.members
 
-    # Check invitation status updated
+    # Check invitation remains pending (not auto-accepted)
     db.session.refresh(invitation)
-    assert invitation.status == "accepted"
+    assert invitation.status == "pending"

--- a/tests/test_group_delete.py
+++ b/tests/test_group_delete.py
@@ -134,8 +134,11 @@ def test_delete_group_handles_commit_failure(client, app, monkeypatch):
     monkeypatch.setattr(db.session, "commit", real_commit)
 
 
-def test_create_group_adds_existing_and_invites_others(client, app):
-    """Creating a group with a mix of existing users and unknown emails should add existing users and create invitations."""
+def test_create_group_creates_invitations_for_all_users(client, app):
+    """Creating a group with a mix of existing users and unknown emails should create invitations for both.
+    
+    All users (existing or new) must accept invitations to join groups.
+    """
     from extensions import db
     from models import GroupInvitation
 
@@ -158,10 +161,18 @@ def test_create_group_adds_existing_and_invites_others(client, app):
 
     group = Group.query.filter_by(name="MixedGroup").first()
     assert group is not None
-    # existing user should be a member
-    assert any(m.email == existing.email for m in group.members)
-    # newinvite should have an invitation
-    assert GroupInvitation.query.filter_by(email="newinvite@example.com", group_id=group.id).first() is not None
+    
+    # Both existing user and new user should have invitations
+    existing_inv = GroupInvitation.query.filter_by(email=existing.email, group_id=group.id).first()
+    new_inv = GroupInvitation.query.filter_by(email="newinvite@example.com", group_id=group.id).first()
+    assert existing_inv is not None
+    assert new_inv is not None
+    assert existing_inv.status == "pending"
+    assert new_inv.status == "pending"
+    
+    # Neither should be members yet (must accept invitation first)
+    assert len(group.members) == 1  # Only creator
+    assert not any(m.email == existing.email for m in group.members)
 
 
 def test_group_expenses_create_percentage_and_shares(client, app):

--- a/tests/test_group_invitations.py
+++ b/tests/test_group_invitations.py
@@ -33,7 +33,10 @@ def test_group_invitation_model_creation(app):
 
 
 def test_create_group_with_non_existent_member_creates_invitation(client, app):
-    """Test that creating a group with non-existent member email creates an invitation."""
+    """Test that creating a group creates invitations for both existing and non-existent users.
+    
+    All users must manually accept invitations to join groups.
+    """
     from extensions import db
 
     # Arrange - Create logged-in user
@@ -45,16 +48,16 @@ def test_create_group_with_non_existent_member_creates_invitation(client, app):
         session["user_id"] = creator.id
         session["user_email"] = creator.email
 
-    # Act - Create group with non-existent member
-    group_data = {
-        "name": "Test Group",
-        "members": "existing@example.com, newuser@example.com",
-    }
-
     # Pre-create existing user
     existing_user = User(email="existing@example.com")
     db.session.add(existing_user)
     db.session.commit()
+
+    # Act - Create group with mix of existing and non-existent members
+    group_data = {
+        "name": "Test Group",
+        "members": "existing@example.com, newuser@example.com",
+    }
 
     response = client.post("/groups/create", data=group_data, follow_redirects=False)
 
@@ -65,19 +68,30 @@ def test_create_group_with_non_existent_member_creates_invitation(client, app):
     group = Group.query.filter_by(name="Test Group").first()
     assert group is not None
 
-    # Check existing user was added to group
-    assert existing_user in group.members
+    # Check existing user NOT automatically added (must accept invitation)
+    assert existing_user not in group.members
+    assert len(group.members) == 1  # Only creator
 
-    # Check invitation was created for non-existent user
-    invitation = GroupInvitation.query.filter_by(email="newuser@example.com").first()
-    assert invitation is not None
-    assert invitation.group_id == group.id
-    assert invitation.invited_by_id == creator.id
-    assert invitation.status == "pending"
+    # Check invitations were created for BOTH users
+    existing_invitation = GroupInvitation.query.filter_by(email="existing@example.com").first()
+    new_invitation = GroupInvitation.query.filter_by(email="newuser@example.com").first()
+    
+    assert existing_invitation is not None
+    assert existing_invitation.group_id == group.id
+    assert existing_invitation.invited_by_id == creator.id
+    assert existing_invitation.status == "pending"
+    
+    assert new_invitation is not None
+    assert new_invitation.group_id == group.id
+    assert new_invitation.invited_by_id == creator.id
+    assert new_invitation.status == "pending"
 
 
-def test_create_group_with_existing_members_no_invitation(client, app):
-    """Test that creating a group with all existing members does not create invitations."""
+def test_create_group_with_existing_members_creates_invitations(client, app):
+    """Test that creating a group with existing members creates invitations for them.
+    
+    Users must manually accept invitations, even if they already have accounts.
+    """
     from extensions import db
 
     # Arrange - Create users
@@ -102,13 +116,18 @@ def test_create_group_with_existing_members_no_invitation(client, app):
     # Assert
     assert response.status_code == 302
 
-    # Check no invitations were created
+    # Check invitations WERE created for existing users
     invitations = GroupInvitation.query.all()
-    assert len(invitations) == 0
+    assert len(invitations) == 2
+    assert {inv.email for inv in invitations} == {"member1@example.com", "member2@example.com"}
+    assert all(inv.status == "pending" for inv in invitations)
 
-    # Check all members were added
+    # Check members were NOT automatically added (must accept invitation first)
     group = Group.query.filter_by(name="Existing Members Group").first()
-    assert len(group.members) == 3  # creator + 2 members
+    assert len(group.members) == 1  # Only creator initially
+    assert creator in group.members
+    assert member1 not in group.members
+    assert member2 not in group.members
 
 
 def test_invitation_notification_is_sent(client, app, capsys):

--- a/tests/test_invitation_routes.py
+++ b/tests/test_invitation_routes.py
@@ -1,0 +1,324 @@
+"""Tests for invitation management routes."""
+
+from models import Group, GroupInvitation, User
+
+
+def test_invitations_list_returns_ok(client, app):
+    """Test that GET /invitations returns 200 and displays pending invitations."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        # Create inviter and invitee users
+        inviter = User(email="inviter@example.com", display_name="Inviter User")
+        invitee = User(email="invitee@example.com", display_name="Invitee User")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        # Create group
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        group.members.append(inviter)
+        db.session.add(group)
+        db.session.commit()
+
+        # Create pending invitation
+        invitation = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+
+    # Login as invitee
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.get("/invitations/")
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Test Group" in response.data
+    assert b"Inviter User" in response.data
+
+
+def test_invitations_list_requires_login(client):
+    """Test that /invitations redirects to login when not authenticated."""
+    # Act
+    response = client.get("/invitations/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+    assert "/auth/login" in response.location
+
+
+def test_accept_invitation_adds_user_to_group(client, app):
+    """Test that POST /invitations/<id>/accept adds user to group."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        group.members.append(inviter)
+        db.session.add(group)
+        db.session.commit()
+
+        invitation = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+        invitation_id = invitation.id
+        group_id = group.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.post(f"/invitations/{invitation_id}/accept", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+    assert "/invitations" in response.location
+
+    # Verify user added to group
+    with app.app_context():
+        group = db.session.get(Group, group_id)
+        invitee = db.session.get(User, invitee_id)
+        assert invitee in group.members
+
+        # Verify invitation status updated
+        invitation = db.session.get(GroupInvitation, invitation_id)
+        assert invitation.status == "accepted"
+
+
+def test_decline_invitation_marks_as_declined(client, app):
+    """Test that POST /invitations/<id>/decline marks invitation as declined."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        group.members.append(inviter)
+        db.session.add(group)
+        db.session.commit()
+
+        invitation = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+        invitation_id = invitation.id
+        group_id = group.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.post(f"/invitations/{invitation_id}/decline", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+    assert "/invitations" in response.location
+
+    # Verify user NOT added to group
+    with app.app_context():
+        group = db.session.get(Group, group_id)
+        invitee = db.session.get(User, invitee_id)
+        assert invitee not in group.members
+
+        # Verify invitation status updated
+        invitation = db.session.get(GroupInvitation, invitation_id)
+        assert invitation.status == "declined"
+
+
+def test_accept_invitation_requires_login(client, app):
+    """Test that accepting invitation requires authentication."""
+    # Arrange
+    with app.app_context():
+        from extensions import db
+
+        inviter = User(email="inviter@example.com")
+        db.session.add(inviter)
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        db.session.add(group)
+        db.session.commit()
+
+        invitation = GroupInvitation(
+            email="test@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+        invitation_id = invitation.id
+
+    # Act (not logged in)
+    response = client.post(f"/invitations/{invitation_id}/accept", follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 302
+    assert "/auth/login" in response.location
+
+
+def test_accept_invitation_only_by_invitee(client, app):
+    """Test that only the invited user can accept the invitation."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        other_user = User(email="other@example.com")
+        db.session.add_all([inviter, invitee, other_user])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        db.session.add(group)
+        db.session.commit()
+
+        invitation = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        other_user_id = other_user.id
+        invitation_id = invitation.id
+
+    # Login as different user
+    with client.session_transaction() as sess:
+        sess["user_id"] = other_user_id
+        sess["user_email"] = "other@example.com"
+
+    # Act
+    response = client.post(f"/invitations/{invitation_id}/accept", follow_redirects=True)
+
+    # Assert
+    assert response.status_code == 200
+    assert b"not authorized" in response.data or b"Not authorized" in response.data
+
+
+def test_invitations_list_only_shows_pending(client, app):
+    """Test that invitations list only shows pending invitations."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group1 = Group(name="Pending Group", created_by_id=inviter.id)
+        group2 = Group(name="Accepted Group", created_by_id=inviter.id)
+        group3 = Group(name="Declined Group", created_by_id=inviter.id)
+        db.session.add_all([group1, group2, group3])
+        db.session.commit()
+
+        # Pending invitation
+        invitation1 = GroupInvitation(
+            email="invitee@example.com", group_id=group1.id, invited_by_id=inviter.id, status="pending"
+        )
+        # Accepted invitation
+        invitation2 = GroupInvitation(
+            email="invitee@example.com", group_id=group2.id, invited_by_id=inviter.id, status="accepted"
+        )
+        # Declined invitation
+        invitation3 = GroupInvitation(
+            email="invitee@example.com", group_id=group3.id, invited_by_id=inviter.id, status="declined"
+        )
+        db.session.add_all([invitation1, invitation2, invitation3])
+        db.session.commit()
+
+        invitee_id = invitee.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.get("/invitations/")
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Pending Group" in response.data
+    assert b"Accepted Group" not in response.data
+    assert b"Declined Group" not in response.data
+
+
+def test_accept_invitation_shows_success_message(client, app):
+    """Test that accepting invitation shows success flash message."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        db.session.add(group)
+        db.session.commit()
+
+        invitation = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+        invitation_id = invitation.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.post(f"/invitations/{invitation_id}/accept", follow_redirects=True)
+
+    # Assert
+    assert response.status_code == 200
+    assert b"accepted" in response.data or b"joined" in response.data
+
+
+def test_invitation_not_found(client, app):
+    """Test that accepting non-existent invitation returns error."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        user = User(email="test@example.com")
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["user_email"] = "test@example.com"
+
+    # Act
+    response = client.post("/invitations/99999/accept", follow_redirects=True)
+
+    # Assert
+    assert response.status_code == 200
+    assert b"not found" in response.data or b"Not found" in response.data

--- a/tests/test_invitation_routes.py
+++ b/tests/test_invitation_routes.py
@@ -322,3 +322,202 @@ def test_invitation_not_found(client, app):
     # Assert
     assert response.status_code == 200
     assert b"not found" in response.data or b"Not found" in response.data
+
+
+def test_decline_invitation_not_found(client, app):
+    """Test that declining non-existent invitation returns error."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        user = User(email="test@example.com")
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["user_email"] = "test@example.com"
+
+    # Act
+    response = client.post("/invitations/99999/decline", follow_redirects=True)
+
+    # Assert
+    assert response.status_code == 200
+    assert b"not found" in response.data or b"Not found" in response.data
+
+
+def test_accept_already_accepted_invitation(client, app):
+    """Test that accepting already-accepted invitation shows info message."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        group.members.append(inviter)
+        db.session.add(group)
+        db.session.commit()
+
+        # Create already-accepted invitation
+        invitation = GroupInvitation(
+            email="invitee@example.com",
+            group_id=group.id,
+            invited_by_id=inviter.id,
+            status="accepted",
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+        invitation_id = invitation.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.post(
+        f"/invitations/{invitation_id}/accept", follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"already been processed" in response.data or b"processed" in response.data
+
+
+def test_decline_already_declined_invitation(client, app):
+    """Test that declining already-declined invitation shows info message."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        group.members.append(inviter)
+        db.session.add(group)
+        db.session.commit()
+
+        # Create already-declined invitation
+        invitation = GroupInvitation(
+            email="invitee@example.com",
+            group_id=group.id,
+            invited_by_id=inviter.id,
+            status="declined",
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+        invitation_id = invitation.id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.post(
+        f"/invitations/{invitation_id}/decline", follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"already been processed" in response.data or b"processed" in response.data
+
+
+def test_accept_invitation_database_error(client, app, monkeypatch):
+    """Test that accept_invitation handles database errors gracefully."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        group.members.append(inviter)
+        db.session.add(group)
+        db.session.commit()
+
+        invitation = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+        invitation_id = invitation.id
+
+    # Mock db.session.commit to raise an exception
+    def mock_commit():
+        raise Exception("Database error")
+
+    monkeypatch.setattr("extensions.db.session.commit", mock_commit)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.post(
+        f"/invitations/{invitation_id}/accept", follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Failed to accept invitation" in response.data or b"error" in response.data
+
+
+def test_decline_invitation_database_error(client, app, monkeypatch):
+    """Test that decline_invitation handles database errors gracefully."""
+    # Arrange
+    from extensions import db
+
+    with app.app_context():
+        inviter = User(email="inviter@example.com")
+        invitee = User(email="invitee@example.com")
+        db.session.add_all([inviter, invitee])
+        db.session.commit()
+
+        group = Group(name="Test Group", created_by_id=inviter.id)
+        group.members.append(inviter)
+        db.session.add(group)
+        db.session.commit()
+
+        invitation = GroupInvitation(
+            email="invitee@example.com", group_id=group.id, invited_by_id=inviter.id
+        )
+        db.session.add(invitation)
+        db.session.commit()
+
+        invitee_id = invitee.id
+        invitation_id = invitation.id
+
+    # Mock db.session.commit to raise an exception
+    def mock_commit():
+        raise Exception("Database error")
+
+    monkeypatch.setattr("extensions.db.session.commit", mock_commit)
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = invitee_id
+        sess["user_email"] = "invitee@example.com"
+
+    # Act
+    response = client.post(
+        f"/invitations/{invitation_id}/decline", follow_redirects=True
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert b"Failed to decline invitation" in response.data or b"error" in response.data


### PR DESCRIPTION
## Description
Implemented manual invitation acceptance/decline feature. Users now receive group invitations and must explicitly accept or decline them via a dedicated invitations page, replacing the previous auto-accept behavior.

## User Story
**As a** user who receives a group invitation  
**I want** to accept or decline the invitation  
**So that** I have control over which groups I join and can review group details before becoming a member

## Changes
- Added `/invitations/` route with list, accept, and decline functionality
- Created `routes/invitations.py` blueprint with 3 endpoints (list, accept, decline)
- Built `templates/invitations/index.html` with Accept/Decline buttons for each pending invitation
- Removed auto-accept logic from `routes/auth.py` (lines 127-134)
- Fixed bug where existing users were auto-added to groups without consent
- Modified `routes/groups.py` to create invitations for ALL users (existing and new)
- Added "Invitations" link to navigation bar (desktop and mobile)
- Updated `tests/conftest.py` to set `EMAIL_ENABLED=False` for consistent test behavior
- Updated 3 existing tests to reflect new manual acceptance behavior
- Created 9 comprehensive tests in `tests/test_invitation_routes.py`

## Testing
- [x] All tests pass locally ✅ (318 tests passing)
- [x] Coverage: 71% for invitations.py (new file), 91% for groups.py, 93% overall ✅
- [x] Manual testing completed ✅ (tested with 2 different email accounts)
- [x] No regressions found ✅

## Screenshots (if UI changed)

Invitations page:

<img width="1289" height="472" alt="Screenshot 2025-11-09 164028" src="https://github.com/user-attachments/assets/cbd99ed4-63e9-4007-9524-bf3a8a9bb6d1" />

Accept or Reject an invite:

<img width="1274" height="297" alt="Screenshot 2025-11-09 164925" src="https://github.com/user-attachments/assets/a0a7c8f1-61ef-4c19-b0c3-5cc3e98af805" />

Group page after a user rejects the invite. There is only 1 user for 'College' group:

<img width="1279" height="487" alt="Screenshot 2025-11-09 164958" src="https://github.com/user-attachments/assets/a9a452b4-1349-4c0c-be96-7f94687d92d6" />


## Checklist
- [x] Code follows project conventions (conventional commits)
- [x] Tests written following TDD approach (RED → GREEN → REFACTOR)
- [x] Documentation updated (if needed)
- [x] No merge conflicts with develop branch
- [x] All CI checks passing

## Related Issues
Closes #26