### PR TITLE
feat: add group limit

### DIFF
--- a/routes/groups.py
+++ b/routes/groups.py
@@ -297,6 +297,15 @@ def create_group():
     # Validate all email formats BEFORE any DB operations
     if member_emails:
         emails = [email.strip() for email in member_emails.split(",") if email.strip()]
+        
+        # Filter out creator's email if included
+        emails = [email for email in emails if email != creator.email]
+        
+        # Check maximum limit: creator + 4 emails = 5 total participants
+        if len(emails) > 4:
+            flash("Maximum 4 additional member emails allowed. The total group size cannot exceed 5 participants (including you as the creator).", "error")
+            return redirect(url_for("groups.create_group"))
+        
         for email in emails:
             if not is_valid_email(email):
                 flash(f"Invalid email format: {email}", "error")
@@ -317,10 +326,10 @@ def create_group():
         # Add other members if emails provided
         if member_emails:
             emails = [email.strip() for email in member_emails.split(",") if email.strip()]
+            # Filter out creator's email if included
+            emails = [email for email in emails if email != creator.email]
 
             for email in emails:
-                if email == creator.email:
-                    continue  # Skip creator (already added)
 
                 # Check if invitation already exists (whether user exists or not)
                 existing_invitation = GroupInvitation.query.filter_by(
@@ -1857,6 +1866,11 @@ def invite_members(group_id):
     if user not in group.members:
         flash("You are not a member of this group", "error")
         return redirect(url_for("groups.list_groups"))
+
+    # Check if group has reached the maximum limit of 5 members
+    if len(group.members) >= 5:
+        flash("Group limit reached!", "error")
+        return redirect(url_for("groups.group_settings", group_id=group_id))
 
     # Get email addresses from form
     member_emails = request.form.get("member_emails", "").strip()

--- a/templates/groups/create.html
+++ b/templates/groups/create.html
@@ -82,8 +82,19 @@
                 <label for="members" class="block text-xs font-medium text-cyan-400 mb-2 uppercase tracking-wider">Additional Member Emails (Optional)</label>
                 <textarea id="members" name="members"
                     class="w-full px-4 py-2 bg-slate-950/50 border border-cyan-500/30 rounded-lg focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all duration-200 font-mono text-white placeholder-gray-500"
-                    placeholder="alice@example.com, bob@example.com" rows="4"></textarea>
-                <span class="text-xs text-gray-400 mt-1">Comma-separated email addresses. You (the creator) will be added automatically.</span>
+                    placeholder="alice@example.com, bob@example.com" rows="4" oninput="validateEmailCount(this)"></textarea>
+                <div class="mt-2">
+                    <span class="text-xs text-gray-400">Comma-separated email addresses. You (the creator) will be added automatically.</span>
+                    <div id="email-count-warning" class="hidden mt-2 p-2 bg-red-500/20 border border-red-500/50 rounded text-xs text-red-400">
+                        <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                        <span class="font-bold">Maximum 4 emails allowed!</span> The total group size cannot exceed 5 participants (including you).
+                    </div>
+                    <div class="text-xs text-cyan-400 mt-1">
+                        <span id="email-count">0</span>/4 emails entered
+                    </div>
+                </div>
             </div>
 
             <div class="flex gap-3 pt-4">
@@ -107,5 +118,50 @@
         </div>
     </div>
 </div>
+
+<script>
+function validateEmailCount(textarea) {
+    const value = textarea.value.trim();
+    const warningDiv = document.getElementById('email-count-warning');
+    const countSpan = document.getElementById('email-count');
+    
+    if (!value) {
+        countSpan.textContent = '0';
+        warningDiv.classList.add('hidden');
+        return;
+    }
+    
+    // Split by comma and filter out empty strings
+    const emails = value.split(',').map(email => email.trim()).filter(email => email.length > 0);
+    const emailCount = emails.length;
+    
+    countSpan.textContent = emailCount;
+    
+    if (emailCount > 4) {
+        warningDiv.classList.remove('hidden');
+        textarea.classList.add('border-red-500');
+        textarea.classList.remove('border-cyan-500/30');
+    } else {
+        warningDiv.classList.add('hidden');
+        textarea.classList.remove('border-red-500');
+        textarea.classList.add('border-cyan-500/30');
+    }
+}
+
+// Validate on form submit
+document.querySelector('form').addEventListener('submit', function(e) {
+    const textarea = document.getElementById('members');
+    const value = textarea.value.trim();
+    
+    if (value) {
+        const emails = value.split(',').map(email => email.trim()).filter(email => email.length > 0);
+        if (emails.length > 4) {
+            e.preventDefault();
+            alert('Maximum 4 additional member emails allowed. The total group size cannot exceed 5 participants (including you as the creator).');
+            return false;
+        }
+    }
+});
+</script>
 {% endblock %}
 

--- a/templates/groups/settings.html
+++ b/templates/groups/settings.html
@@ -10,7 +10,16 @@
             <div class="mb-6">
                 {% for category, message in messages %}
                     <div class="p-4 rounded-lg {% if category == 'error' %}bg-red-50 border border-red-200 text-red-800{% else %}bg-green-50 border border-green-200 text-green-800{% endif %}">
-                        {{ message }}
+                        {% if category == 'error' and 'Group limit reached' in message %}
+                            <div class="flex items-center gap-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                                </svg>
+                                <span class="font-bold">{{ message }}</span>
+                            </div>
+                        {% else %}
+                            {{ message }}
+                        {% endif %}
                     </div>
                 {% endfor %}
             </div>
@@ -158,6 +167,18 @@
             <h3 class="text-lg font-semibold text-gray-700 mb-3">Invite New Members</h3>
             <p class="text-gray-600 mb-4">Enter email addresses to invite people to join this group. They will receive an invitation email.</p>
             
+            {% if group.members|length >= 5 %}
+            <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+                <div class="flex items-center gap-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                    <span class="font-bold text-red-800">Group limit reached!</span>
+                </div>
+                <p class="text-sm text-red-700 mt-2">This group has reached the maximum limit of 5 members. You cannot invite more members.</p>
+            </div>
+            {% endif %}
+            
             <form action="{{ url_for('groups.invite_members', group_id=group.id) }}" method="POST">
                 <div class="flex items-start gap-4">
                     <div class="flex-grow">
@@ -168,12 +189,14 @@
                                id="member_emails" 
                                name="member_emails"
                                placeholder="user@example.com, another@example.com"
-                               class="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+                               class="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 {% if group.members|length >= 5 %}bg-gray-100 cursor-not-allowed{% endif %}"
+                               {% if group.members|length >= 5 %}disabled{% endif %}
                                required>
                         <p class="text-xs text-gray-500 mt-1">Separate multiple email addresses with commas</p>
                     </div>
                     <button type="submit"
-                            class="mt-7 px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 transition-colors">
+                            class="mt-7 px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 transition-colors {% if group.members|length >= 5 %}opacity-50 cursor-not-allowed{% endif %}"
+                            {% if group.members|length >= 5 %}disabled{% endif %}>
                         Send Invitations
                     </button>
                 </div>

--- a/tests/test_group_routes.py
+++ b/tests/test_group_routes.py
@@ -88,6 +88,30 @@ def test_groups_create_group_rejects_invalid_member_emails(client, app):
     assert Group.query.filter_by(name="Invalid Email Group").first() is None
 
 
+def test_groups_create_group_rejects_more_than_four_members(client, app):
+    """Test that POST /groups/create rejects more than 4 additional member emails."""
+    from extensions import db
+
+    creator = User(email="limit@test.com")
+    db.session.add(creator)
+    db.session.commit()
+
+    with client.session_transaction() as session:
+        session["user_id"] = creator.id
+        session["user_email"] = creator.email
+
+    group_data = {
+        "name": "Too Many Members",
+        "members": "a@test.com, b@test.com, c@test.com, d@test.com, e@test.com",
+    }
+
+    response = client.post("/groups/create", data=group_data, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"Maximum 4 additional member emails allowed" in response.data
+    assert Group.query.filter_by(name="Too Many Members").first() is None
+
+
 def test_groups_create_group_without_members(client, app):
     """Test that POST /groups/create works without optional members."""
     # Arrange

--- a/tests/test_group_settings.py
+++ b/tests/test_group_settings.py
@@ -709,6 +709,50 @@ class TestMemberManagement:
         assert "user2@test.com" in emails
         assert "user3@test.com" in emails
 
+    
+    def test_invite_members_rejects_when_group_full(self, client, auth_user):
+        """Test inviting members fails when group already has 5 participants."""
+        from models import GroupInvitation
+    
+        with client.session_transaction() as sess:
+            sess["user_id"] = auth_user.id
+            sess["user_email"] = auth_user.email
+    
+        creator = db.session.get(User, auth_user.id)
+    
+        # Create group and add it to session FIRST
+        group = Group(name="Full Group", created_by_id=creator.id)
+        db.session.add(group)
+    
+        # Flush so group gets an ID before adding members
+        db.session.flush()
+    
+        # Add creator as member
+        group.members.append(creator)
+    
+        # Add four additional members to reach 5 total participants
+        for idx in range(4):
+            member = User(email=f"member{idx}@test.com")
+            db.session.add(member)
+            db.session.flush()
+            group.members.append(member)
+    
+        db.session.commit()
+    
+        response = client.post(
+            f"/groups/{group.id}/invite-members",
+            data={"member_emails": "newmember@test.com"},
+            follow_redirects=True,
+        )
+    
+        assert response.status_code == 200
+        assert b"Group limit reached!" in response.data
+    
+        assert (
+            GroupInvitation.query.filter_by(email="newmember@test.com", group_id=group.id).first()
+            is None
+        )
+
     def test_invite_members_already_member(self, client, auth_user):
         """Test inviting user who is already a member."""
         with client.session_transaction() as sess:
@@ -1125,3 +1169,6 @@ class TestEditGroupName:
         assert b"group_name" in response.data
         assert b"Save Name" in response.data
         assert b"Test Group" in response.data  # Current name should be in input
+
+    
+    


### PR DESCRIPTION
📋 Description
A group cannot have more than 5 participants. Similarly, when the admin or the creator is trying to create a group, he or she cannot add more than 4 invite links since the creator is considered as one participant too.

🎯 Changes Made
Added a warning message near the place where the group creation happens. Also, below the "Manage members", it again displays a warning message once the number of participants in the group is 5.

🧪 Testing
All tests pass (uv run pytest -v) 
Coverage meets requirements (92% overall) 
Added new tests for group limit
<img width="841" height="499" alt="Screenshot 2025-11-28 at 10 09 37 AM" src="https://github.com/user-attachments/assets/dd2c861d-95fc-4f78-a0bd-195c48ffff03" />


🔗 Related Story
Closes https://github.com/PradHolla/CS-555-A-Course-Project/issues/16

Screenshots:
<img width="798" height="682" alt="Screenshot 2025-11-28 at 1 22 51 AM" src="https://github.com/user-attachments/assets/c9e4a66f-8afe-42ab-8053-2e8418f540ab" />

<img width="801" height="713" alt="Screenshot 2025-11-28 at 1 22 59 AM" src="https://github.com/user-attachments/assets/d6d101ff-6645-4545-af9a-c5105131a096" />

<img width="892" height="685" alt="Screenshot 2025-11-28 at 1 26 29 AM" src="https://github.com/user-attachments/assets/749a6381-f573-48d1-adcb-4b19a23b5160" />


🔄 Files Changed
routes/groups.py
templates/groups/create.html
templates/groups/settings.html
tests/test_group_routes.py
tests/test_group_settings.py